### PR TITLE
layered caching for session stores

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,7 +112,7 @@ jobs:
           - test: sqlite-store
             features: sqlite-store
             docker: false
-          - test: moka-store-dummy
+          - test: moka-store
             features: moka-store
             docker: false
           - test: moka-store-sqlite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ tower-cookies = "0.9"
 tower-layer = "0.3"
 tower-service = "0.3"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
+futures = { version = "0.3.28", default-features = false, features = [
+    "async-await",
+] }
 
 axum-core = { optional = true, version = "0.3" }
 fred = { optional = true, version = "6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,6 @@ tower-cookies = "0.9"
 tower-layer = "0.3"
 tower-service = "0.3"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
-futures = { version = "0.3.28", default-features = false, features = [
-    "async-await",
-] }
 
 axum-core = { optional = true, version = "0.3" }
 fred = { optional = true, version = "6" }
@@ -46,9 +43,9 @@ rmp-serde = { optional = true, version = "1.1.2" }
 mongodb = { optional = true, version = "2.7.0-beta" }
 bson = { optional = true, version = "2.7.0", features = ["time-0_3", "uuid-1"] }
 sqlx = { optional = true, version = "0.7.1", features = [
-    "time",
-    "uuid",
-    "runtime-tokio",
+  "time",
+  "uuid",
+  "runtime-tokio",
 ] }
 tokio = { optional = true, version = "1", features = ["full"] }
 moka = { optional = true, version = "0.12.0", features = ["future"] }

--- a/examples/moka-postgres-store.rs
+++ b/examples/moka-postgres-store.rs
@@ -7,7 +7,9 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
-use tower_sessions::{sqlx::PgPool, MokaStore, PostgresStore, Session, SessionManagerLayer};
+use tower_sessions::{
+    sqlx::PgPool, CachingSessionStore, MokaStore, PostgresStore, Session, SessionManagerLayer,
+};
 
 const COUNTER_KEY: &str = "counter";
 
@@ -18,17 +20,19 @@ struct Counter(usize);
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database_url = std::option_env!("DATABASE_URL").expect("Missing DATABASE_URL.");
     let pool = PgPool::connect(database_url).await?;
+
     let postgres_store = PostgresStore::new(pool);
     postgres_store.migrate().await?;
 
-    let moka_store = MokaStore::new(postgres_store, Some(2000));
+    let moka_store = MokaStore::new(Some(2000));
+    let caching_store = CachingSessionStore::new(moka_store, postgres_store);
 
     let session_service = ServiceBuilder::new()
         .layer(HandleErrorLayer::new(|_: BoxError| async {
             StatusCode::BAD_REQUEST
         }))
         .layer(
-            SessionManagerLayer::new(moka_store)
+            SessionManagerLayer::new(caching_store)
                 .with_secure(false)
                 .with_max_age(Duration::seconds(10)),
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ pub use self::{
     cookie_config::CookieConfig,
     service::{SessionManager, SessionManagerLayer},
     session::{Session, SessionRecord},
-    session_store::SessionStore,
+    session_store::{CachingSessionStore, SessionStore},
 };
 
 #[cfg(feature = "axum-core")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,7 @@
 //!
 //! When using `axum`, the [`Session`] will already function as an extractor.
 //! It's possible to build further on this to create extractors of custom types.
+//!
 //! ```rust,no_run
 //! # use async_trait::async_trait;
 //! # use axum::extract::FromRequestParts;
@@ -254,6 +255,7 @@
 //! example was effectively read-only. This pattern enables mutability of the
 //! underlying structure while also leveraging the full power of the type
 //! system.
+//!
 //! ```rust,no_run
 //! # use async_trait::async_trait;
 //! # use axum::extract::FromRequestParts;

--- a/src/moka_store.rs
+++ b/src/moka_store.rs
@@ -15,13 +15,13 @@ pub struct MokaStore {
 }
 
 impl MokaStore {
-    /// Create a new MokaStore.
+    /// Create a new Moka store with the provided maximum capacity.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use tower_sessions::{MemoryStore, MokaStore};
-    /// MokaStore::new(Some(2000));
+    /// let session_store = MokaStore::new(Some(2_000));
     /// ```
     pub fn new(max_capacity: Option<u64>) -> Self {
         // it would be useful to expose more of the CacheBuilder options to the user,

--- a/src/moka_store.rs
+++ b/src/moka_store.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use async_trait::async_trait;
 use moka::future::Cache;
 
@@ -7,26 +9,21 @@ use crate::{
 };
 
 /// A session store that uses Moka, a fast and concurrent caching library.
-#[derive(Clone)]
-pub struct MokaStore<T: SessionStore> {
-    // Note: This stores a Session rather than a SessionRecord because otherwise it can't
-    // cache the response when load() is called on the wrapped SessionStore
-    cache: Cache<SessionId, Option<Session>>,
-    wrapped_store: T,
+#[derive(Debug, Clone)]
+pub struct MokaStore {
+    cache: Cache<SessionId, SessionRecord>,
 }
 
-impl<T: SessionStore> MokaStore<T> {
-    /// Create a new MokaStore, that acts as a write-trough cache,
-    /// using the SessionStore provided as the backing store.
+impl MokaStore {
+    /// Create a new MokaStore.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use tower_sessions::{MemoryStore, MokaStore};
-    /// let backing_store = MemoryStore::default();
-    /// MokaStore::new(backing_store, Some(2000));
+    /// MokaStore::new(Some(2000));
     /// ```
-    pub fn new(wrapped_store: T, max_capacity: Option<u64>) -> Self {
+    pub fn new(max_capacity: Option<u64>) -> Self {
         // it would be useful to expose more of the CacheBuilder options to the user,
         // but for now this is the most important one
         let cache_builder = match max_capacity {
@@ -36,76 +33,27 @@ impl<T: SessionStore> MokaStore<T> {
 
         Self {
             cache: cache_builder.build(),
-            wrapped_store,
         }
     }
 }
 
-impl MokaStore<DummyStore> {
-    /// Create a new MokaStore, that acts as a in-memory only store, with no
-    /// backing store.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tower_sessions::MokaStore;
-    /// MokaStore::new_in_memory();
-    /// ```
-    pub fn new_in_memory() -> Self {
-        Self::new(DummyStore::default(), None)
-    }
-}
-
 #[async_trait]
-impl<T: SessionStore> SessionStore for MokaStore<T> {
-    type Error = T::Error;
+impl SessionStore for MokaStore {
+    type Error = Infallible;
 
     async fn save(&self, session_record: &SessionRecord) -> Result<(), Self::Error> {
-        self.wrapped_store.save(session_record).await?;
-
         self.cache
-            .insert(session_record.id(), Some(session_record.clone().into()))
+            .insert(session_record.id(), session_record.clone())
             .await;
-
         Ok(())
     }
 
     async fn load(&self, session_id: &SessionId) -> Result<Option<Session>, Self::Error> {
-        let session = match self.cache.get(session_id).await {
-            Some(session) => session,
-            None => {
-                let session = self.wrapped_store.load(session_id).await?;
-                self.cache.insert(*session_id, session.clone()).await;
-                session
-            }
-        };
-
-        Ok(session)
+        Ok(self.cache.get(session_id).await.map(Into::into))
     }
 
     async fn delete(&self, session_id: &SessionId) -> Result<(), Self::Error> {
-        self.wrapped_store.delete(session_id).await?;
         self.cache.invalidate(session_id).await;
-        Ok(())
-    }
-}
-
-#[derive(Clone, Default)]
-pub struct DummyStore;
-
-#[async_trait]
-impl SessionStore for DummyStore {
-    type Error = std::convert::Infallible;
-
-    async fn save(&self, _session_record: &SessionRecord) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    async fn load(&self, _session_id: &SessionId) -> Result<Option<Session>, Self::Error> {
-        Ok(None)
-    }
-
-    async fn delete(&self, _session_id: &SessionId) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -372,6 +372,7 @@ impl Session {
     /// use tower_sessions::Session;
     /// let session = Session::default();
     /// session.set_expiration_time(OffsetDateTime::now_utc());
+    /// session.insert("foo", 42);
     /// assert!(!session.active());
     /// assert!(session.modified());
     ///
@@ -397,6 +398,7 @@ impl Session {
     /// use time::Duration;
     /// use tower_sessions::Session;
     /// let session = Session::default();
+    /// session.insert("foo", 42);
     /// session.set_expiration_time_from_max_age(Duration::minutes(5));
     /// assert!(session.active());
     /// assert!(session.modified());

--- a/src/session.rs
+++ b/src/session.rs
@@ -485,13 +485,13 @@ impl Session {
     /// ```rust
     /// use tower_sessions::{Session, SessionRecord};
     /// let session = Session::default();
-    /// assert!(session.empty());
+    /// assert!(session.is_empty());
     /// session.insert("foo", 42);
-    /// assert!(!session.empty());
+    /// assert!(!session.is_empty());
     ///
     /// let tombstone = SessionRecord::tombstone_from_id(session.id());
     /// let session: Session = tombstone.into();
-    /// assert!(session.empty());
+    /// assert!(session.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
         let inner = self.inner.lock();

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -1,4 +1,5 @@
 //! An arbitrary store which houses the session data.
+
 use async_trait::async_trait;
 
 use crate::session::{Session, SessionId, SessionRecord};
@@ -17,4 +18,89 @@ pub trait SessionStore: Clone + Send + Sync + 'static {
 
     /// A method for deleting a session from a store.
     async fn delete(&self, session_id: &SessionId) -> Result<(), Self::Error>;
+}
+
+/// An enumeration of both `SessionStore` error types.
+#[derive(thiserror::Error, Debug)]
+pub enum CachingStoreError<Cache: SessionStore, Store: SessionStore> {
+    /// A cache-related error.
+    #[error(transparent)]
+    Cache(Cache::Error),
+
+    /// A store-related error.
+    #[error(transparent)]
+    Store(Store::Error),
+}
+
+/// TODO.
+#[derive(Debug, Clone)]
+pub struct CachingSessionStore<Cache: SessionStore, Store: SessionStore> {
+    cache: Cache,
+    store: Store,
+}
+
+impl<Cache: SessionStore, Store: SessionStore> CachingSessionStore<Cache, Store> {
+    /// Create a new `CachingSessionStore`.
+    pub fn new(cache: Cache, store: Store) -> Self {
+        Self { cache, store }
+    }
+}
+
+#[async_trait]
+impl<Cache, Store> SessionStore for CachingSessionStore<Cache, Store>
+where
+    Cache: SessionStore + std::fmt::Debug, // TODO: Why is this required to be Debug?
+    Store: SessionStore + std::fmt::Debug,
+{
+    type Error = CachingStoreError<Cache, Store>;
+
+    async fn save(&self, session_record: &SessionRecord) -> Result<(), Self::Error> {
+        self.store
+            .save(session_record)
+            .await
+            .map_err(Self::Error::Store)?;
+        self.cache
+            .save(session_record)
+            .await
+            .map_err(Self::Error::Cache)?;
+        Ok(())
+    }
+
+    async fn load(&self, session_id: &SessionId) -> Result<Option<Session>, Self::Error> {
+        let session = match self.cache.load(session_id).await {
+            Ok(Some(session)) => Some(session),
+
+            Ok(None) => {
+                let session = self
+                    .store
+                    .load(session_id)
+                    .await
+                    .map_err(Self::Error::Store)?;
+                if let Some(session) = session.clone() {
+                    let session_record = (&session).into();
+                    self.cache
+                        .save(&session_record)
+                        .await
+                        .map_err(Self::Error::Cache)?;
+                }
+                session
+            }
+
+            Err(err) => return Err(Self::Error::Cache(err)),
+        };
+
+        Ok(session)
+    }
+
+    async fn delete(&self, session_id: &SessionId) -> Result<(), Self::Error> {
+        self.store
+            .delete(session_id)
+            .await
+            .map_err(Self::Error::Store)?;
+        self.cache
+            .delete(session_id)
+            .await
+            .map_err(Self::Error::Cache)?;
+        Ok(())
+    }
 }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -92,7 +92,7 @@ where
     async fn load(&self, session_id: &SessionId) -> Result<Option<Session>, Self::Error> {
         match self.cache.load(session_id).await {
             // We found a session in the cache, so let's use it.
-            Ok(Some(session)) => Ok(Some(session).filter(|s| !s.is_tombstone())),
+            Ok(Some(session)) => Ok(Some(session).filter(|s| !s.is_empty())),
 
             // We didn't find a session in the cache, so we'll try loading from the backend.
             //
@@ -113,7 +113,7 @@ where
                 } else {
                     // If we know the session doesn't exist in the store, we cache the negative
                     // lookup to avoid future roundtrips to the store.
-                    let tombstone = SessionRecord::new_tombstone(*session_id);
+                    let tombstone = SessionRecord::tombstone_from_id(*session_id);
                     self.cache
                         .save(&tombstone)
                         .await

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -45,10 +45,16 @@ pub enum CachingStoreError<Cache: SessionStore, Store: SessionStore> {
 /// # Examples
 ///
 /// ```rust
-/// use tower_sessions::{CachingSessionStore, MokaStore, SqliteStore};
-/// let sqlite_store = SqliteStore::new("sqlite::memory:");
+/// # #[cfg(all(feature = "moka_store", feature = "sqlite_store"))]
+/// # {
+/// # tokio_test::block_on(async {
+/// use tower_sessions::{CachingSessionStore, MokaStore, SqlitePool, SqliteStore};
+/// let pool = SqlitePool::connect("sqlite::memory:").await?;
+/// let sqlite_store = SqliteStore::new(pool);
 /// let moka_store = MokaStore::new(Some(2_000));
-/// CachingSessionStore::new(moka_store, sqlite_store);
+/// let caching_store = CachingSessionStore::new(moka_store, sqlite_store);
+/// # })
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct CachingSessionStore<Cache: SessionStore, Store: SessionStore> {

--- a/tests/moka-store-integration-tests.rs
+++ b/tests/moka-store-integration-tests.rs
@@ -8,10 +8,8 @@ use tower_sessions::{MokaStore, SessionManagerLayer};
 
 #[cfg(all(test, feature = "axum-core", feature = "moka-store"))]
 async fn app(max_age: Option<Duration>) -> Router {
-    let moka_store = MokaStore::new_in_memory();
-
+    let moka_store = MokaStore::new(None);
     let session_manager = SessionManagerLayer::new(moka_store).with_secure(true);
-
     build_app(session_manager, max_age)
 }
 

--- a/tests/moka-store-sqlite-integration-tests.rs
+++ b/tests/moka-store-sqlite-integration-tests.rs
@@ -18,12 +18,14 @@ use tower_sessions::{sqlx::SqlitePool, MokaStore, SessionManagerLayer, SqliteSto
     feature = "moka-store"
 ))]
 async fn app(max_age: Option<Duration>) -> Router {
+    use tower_sessions::CachingSessionStore;
+
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     let sqlite_store = SqliteStore::new(pool);
     sqlite_store.migrate().await.unwrap();
-    let moka_store = MokaStore::new(sqlite_store, None);
-
-    let session_manager = SessionManagerLayer::new(moka_store).with_secure(true);
+    let moka_store = MokaStore::new(None);
+    let caching_store = CachingSessionStore::new(moka_store, sqlite_store);
+    let session_manager = SessionManagerLayer::new(caching_store).with_secure(true);
 
     build_app(session_manager, max_age)
 }


### PR DESCRIPTION
This implements `CachingSessionStore`, which holds two `SessionStore`s. One acts as a frontend cache, while the other asks as the backend persistence store.

Anything that implements `SessionStore` may be used as either the cache or the store.

We also refactor our Moka implementation as it can now be used for layered caching directly in via `CachingSessionStore`.