### PR TITLE
rework session expiration time management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+**BREAKING CHANGES**
+
+- Replaced `Session.with_max_age` with `set_expiration_time` and `set_expiration_time_from_max_age`, allowing applications to control session durations dynamically. #7
+
+**OTHER CHANGES**
+
+- Provide a Moka store #6 (Thank you @and-reas-se!)
+- Provide a MongoDB store #5 (Thank you @JustMangoT!)
+
 # 0.1.0
 
 - Initial release :tada:

--- a/src/cookie_config.rs
+++ b/src/cookie_config.rs
@@ -63,7 +63,7 @@ impl CookieConfig {
     ///
     /// ```rust
     /// use tower_sessions::{CookieConfig, Session};
-    /// let session = Session::new();
+    /// let session = Session::default();
     /// let cookie_config = CookieConfig::default();
     /// let cookie = cookie_config.build_cookie(&session);
     /// assert_eq!(cookie.value(), session.id().to_string());

--- a/src/session.rs
+++ b/src/session.rs
@@ -58,55 +58,6 @@ impl Session {
         }
     }
 
-    /// Set `expiration_time` give the given value.
-    ///
-    /// This may be used within applications directly to extend the session's
-    /// time to live.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use time::{Duration, OffsetDateTime};
-    /// use tower_sessions::Session;
-    /// let session = Session::default();
-    /// session.set_expiration_time(OffsetDateTime::now_utc());
-    /// assert!(!session.active());
-    /// assert!(session.modified());
-    ///
-    /// session.set_expiration_time(OffsetDateTime::now_utc().saturating_add(Duration::hours(1)));
-    /// assert!(session.active());
-    /// assert!(session.modified());
-    /// ```
-    pub fn set_expiration_time(&self, expiration_time: OffsetDateTime) {
-        let mut inner = self.inner.lock();
-        inner.expiration_time = Some(expiration_time);
-        inner.modified = true;
-    }
-
-    /// Set `expiration_time` to current time in UTC plus the given `max_age`
-    /// duration.
-    ///
-    /// This may be used within applications directly to extend the session's
-    /// time to live.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use time::Duration;
-    /// use tower_sessions::Session;
-    /// let session = Session::default();
-    /// session.set_expiration_time_from_max_age(Duration::minutes(5));
-    /// assert!(session.active());
-    /// assert!(session.modified());
-    ///
-    /// session.set_expiration_time_from_max_age(Duration::ZERO);
-    /// assert!(!session.active());
-    /// assert!(session.modified());
-    /// ```
-    pub fn set_expiration_time_from_max_age(&self, max_age: Duration) {
-        self.set_expiration_time(OffsetDateTime::now_utc().saturating_add(max_age));
-    }
-
     /// Inserts a `impl Serialize` value into the session.
     ///
     /// # Examples
@@ -407,6 +358,55 @@ impl Session {
     pub fn expiration_time(&self) -> Option<OffsetDateTime> {
         let inner = self.inner.lock();
         inner.expiration_time
+    }
+
+    /// Set `expiration_time` give the given value.
+    ///
+    /// This may be used within applications directly to extend the session's
+    /// time to live.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use time::{Duration, OffsetDateTime};
+    /// use tower_sessions::Session;
+    /// let session = Session::default();
+    /// session.set_expiration_time(OffsetDateTime::now_utc());
+    /// assert!(!session.active());
+    /// assert!(session.modified());
+    ///
+    /// session.set_expiration_time(OffsetDateTime::now_utc().saturating_add(Duration::hours(1)));
+    /// assert!(session.active());
+    /// assert!(session.modified());
+    /// ```
+    pub fn set_expiration_time(&self, expiration_time: OffsetDateTime) {
+        let mut inner = self.inner.lock();
+        inner.expiration_time = Some(expiration_time);
+        inner.modified = true;
+    }
+
+    /// Set `expiration_time` to current time in UTC plus the given `max_age`
+    /// duration.
+    ///
+    /// This may be used within applications directly to extend the session's
+    /// time to live.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use time::Duration;
+    /// use tower_sessions::Session;
+    /// let session = Session::default();
+    /// session.set_expiration_time_from_max_age(Duration::minutes(5));
+    /// assert!(session.active());
+    /// assert!(session.modified());
+    ///
+    /// session.set_expiration_time_from_max_age(Duration::ZERO);
+    /// assert!(!session.active());
+    /// assert!(session.modified());
+    /// ```
+    pub fn set_expiration_time_from_max_age(&self, max_age: Duration) {
+        self.set_expiration_time(OffsetDateTime::now_utc().saturating_add(max_age));
     }
 
     /// Returns `true` if the session is active and `false` otherwise.

--- a/src/session.rs
+++ b/src/session.rs
@@ -270,7 +270,6 @@ impl Session {
     /// This flag is consumed by a session management system to ensure session
     /// life cycle progression.
     ///
-    ///
     /// # Examples
     ///
     /// ```rust
@@ -363,7 +362,7 @@ impl Session {
 
     /// Set `expiration_time` give the given value.
     ///
-    /// This may be used within applications directly to extend the session's
+    /// This may be used within applications directly to alter the session's
     /// time to live.
     ///
     /// # Examples
@@ -389,7 +388,7 @@ impl Session {
     /// Set `expiration_time` to current time in UTC plus the given `max_age`
     /// duration.
     ///
-    /// This may be used within applications directly to extend the session's
+    /// This may be used within applications directly to alter the session's
     /// time to live.
     ///
     /// # Examples

--- a/src/session.rs
+++ b/src/session.rs
@@ -35,8 +35,9 @@ pub struct Session {
 impl Session {
     /// Create a new session with defaults.
     ///
-    /// Note that an `expiration_time` of `None` results in a cookie with
-    /// expiration `"Session"`.
+    /// If an `expiration_time` is not specified, the session will use an
+    /// expiration strategy of "Session," which means it will persist only
+    /// until the user's session ends.
     ///
     /// # Examples
     ///

--- a/src/session.rs
+++ b/src/session.rs
@@ -72,10 +72,14 @@ impl Session {
     /// # Examples
     ///
     /// ```rust
-    /// use time::OffsetDateTime;
+    /// use time::{Duration, OffsetDateTime};
     /// use tower_sessions::Session;
     /// let session = Session::default();
     /// session.set_expiration_time(OffsetDateTime::now_utc());
+    /// assert!(!session.active());
+    ///
+    /// session.set_expiration_time(OffsetDateTime::now_utc().saturating_add(Duration::hours(1)));
+    /// assert!(session.active());
     /// ```
     pub fn set_expiration_time(&self, expiration_time: OffsetDateTime) {
         let mut inner = self.inner.lock();
@@ -95,6 +99,10 @@ impl Session {
     /// use tower_sessions::Session;
     /// let session = Session::default();
     /// session.set_expiration_time_from_max_age(Duration::minutes(5));
+    /// assert!(session.active());
+    ///
+    /// session.set_expiration_time_from_max_age(Duration::ZERO);
+    /// assert!(!session.active());
     /// ```
     pub fn set_expiration_time_from_max_age(&self, max_age: Duration) {
         let expiration_time = max_age_to_expiration_time(max_age);


### PR DESCRIPTION
This is a breaking change that moves the expiration time into the inner
state and thus makes it settable from applications that might consume
sessions.

Here we've removed `with_max_age`, and replaced it with two new methods,
`set_expiration_time` and `set_expiration_time_from_max_age` as well as
added an optional expiration time to the session's new method.

Doing so helps us reduce confusion given `with_max_age` is already used
by the service module for a different but related purpose.

Note that creating a session via its default implementation will yield
the same semantics as before.

Closes https://github.com/maxcountryman/tower-sessions/issues/7.