### PR TITLE
ensure sessions are deleted when empty

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -118,6 +118,14 @@ where
                 }
             };
 
+            // In order to ensure removing the last value of a session updates the store, we
+            // check for an empty session. Empty sessions should be removed from the store.
+            if session.is_empty() {
+                session_store.delete(&session.id()).await?;
+                cookies.remove(cookie_config.build_cookie(&session));
+                return res;
+            }
+
             // For further consideration:
             //
             // We only persist the session in the store when the `modified` flag is set.

--- a/src/session.rs
+++ b/src/session.rs
@@ -495,7 +495,7 @@ impl Session {
     /// ```
     pub fn is_empty(&self) -> bool {
         let inner = self.inner.lock();
-        inner.expiration_time.is_none() && inner.data.is_empty()
+        inner.data.is_empty()
     }
 }
 


### PR DESCRIPTION
When a session is empty it should be removed entirely.

Previously this was not the case as the modified flag cannot be set when the underlying session data is empty. This makes sense because an empty session should not be updated but instead deleted.

However, this also meant that removing the last key of a previously stored session would not reflect this update in the store--the session would not be saved to the store or deleted.

To address this, we now look for an empty session after resolving the request. When found, we delete the session from the store and return the response.

Fixes #21.