### PR TITLE
fix session saving and loading data race

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = ["dep:tokio"]
 
 [dependencies]
 async-trait = "0.1.73"
+dashmap = { version = "5.5.3", default-features = false }
 http = "0.2.9"
 futures = { version = "0.3.28", default-features = false, features = [
     "async-await",


### PR DESCRIPTION
This fixes a bug where session data could be lost if a session is loaded from the store while it's also being saved back to the store. Because sessions are loaded and stored in memory at the beginning of a request, it was previously possible for a session's inner value to be correctly altered but for that modification to be lost between the moment the session is saved to the store and when it's loaded. In other words, the data loaded would not reflect the in-progress update and instead be stale.

To address this we could hold a lock for the duration of the request. However, this imposes a performance penalty we would like to avoid. Alternatively we can manage a registry of sessions, a la tower-cookie's management of `CookieJar`: with this, we load a session first from the service's cache of sessions and fallback to the store only when the session is not present.

Currently sessions are managed like this via DashMap. However, alternatively caching facilities, such as Moka, might prove to be a better fit. Further, the current implementation does not bound the total number of cached sessions--this should be addressed in future updates. At present, this means memory will continue to grow, albeit typically at a very small rate; this is a memory leak!

Because sessions are safely written to and read from this cache, we prevent stale reads and thus a data race which could lead to data loss in highly concurrent environments, especially where multiple requests are made using the same session cookie simultaneously.

Note that `replace_if_equal` is still required to prevent data races in application code.