### PR TITLE
fix session saving and loading data race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.2.4
+
+- Fix session saving and loading potential data race. #36
+
 # 0.2.3
 
 - Fix setting of modified in `replace_if_equal`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ sqlite-store = ["sqlx/sqlite", "sqlx-store"]
 postgres-store = ["sqlx/postgres", "sqlx-store"]
 mysql-store = ["sqlx/mysql", "sqlx-store"]
 moka-store = ["moka"]
-tokio = ["dep:tokio"]
+#tokio = ["dep:tokio"]
 
 [dependencies]
 async-trait = "0.1.73"
@@ -41,6 +41,9 @@ tower-layer = "0.3.2"
 tower-service = "0.3.2"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 
+# This is temporarily required; move back to optional once session lock can be removed.
+tokio = { version = "1.32.0", features = ["full"] }
+
 axum-core = { optional = true, version = "0.3.4" }
 fred = { optional = true, version = "6.3.2" }
 rmp-serde = { optional = true, version = "1.1.2" }
@@ -51,7 +54,6 @@ sqlx = { optional = true, version = "0.7.2", features = [
     "uuid",
     "runtime-tokio",
 ] }
-tokio = { optional = true, version = "1.32.0", features = ["full"] }
 moka = { optional = true, version = "0.12.0", features = ["future"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-sessions"
 description = "🥠 Sessions as a `tower` and `axum` middleware."
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Max Countryman <hello@maxcountryman.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use the crate in your project, add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-tower-sessions = "0.2.3"
+tower-sessions = "0.2.4"
 ```
 
 ## 🤸 Usage

--- a/src/mongodb_store.rs
+++ b/src/mongodb_store.rs
@@ -62,6 +62,7 @@ impl MongoDBStore {
         }
     }
 
+    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired documents
     /// and then waiting for the specified period before deleting again.
     ///
@@ -94,7 +95,6 @@ impl MongoDBStore {
     /// );
     /// # })
     /// ```
-    #[cfg(feature = "tokio")]
     pub async fn continuously_delete_expired(
         self,
         period: tokio::time::Duration,

--- a/src/sqlx_store/mysql_store.rs
+++ b/src/sqlx_store/mysql_store.rs
@@ -79,7 +79,7 @@ impl MySqlStore {
         Ok(())
     }
 
-    #[cfg(feature = "tokio")]
+    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired rows and
     /// then waiting for the specified period before deleting again.
     ///

--- a/src/sqlx_store/postgres_store.rs
+++ b/src/sqlx_store/postgres_store.rs
@@ -91,7 +91,7 @@ impl PostgresStore {
         Ok(())
     }
 
-    #[cfg(feature = "tokio")]
+    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired rows and
     /// then waiting for the specified period before deleting again.
     ///

--- a/src/sqlx_store/sqlite_store.rs
+++ b/src/sqlx_store/sqlite_store.rs
@@ -78,7 +78,7 @@ impl SqliteStore {
         Ok(())
     }
 
-    #[cfg(feature = "tokio")]
+    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired rows and
     /// then waiting for the specified period before deleting again.
     ///


### PR DESCRIPTION
This is a temporary fix for a data race that occurs when a session is saved and loaded at the same time. The result of this race is that stale data can be loaded into memory, resulting in potential data loss where multiple requests using the same session are issued simultaneously.

Here we address this by holding a lock for the duration of the request. This solution is only temporary, as the underlying session implementation can instead be modified to ensure safe access between the save and load await points.

This supercedes #35.