### PR TITLE
track loaded sessions to enable concurrent access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ sqlite-store = ["sqlx/sqlite", "sqlx-store"]
 postgres-store = ["sqlx/postgres", "sqlx-store"]
 mysql-store = ["sqlx/mysql", "sqlx-store"]
 moka-store = ["moka"]
+tokio-rt = ["tokio/rt"]
 
 [dependencies]
 async-trait = "0.1.73"
@@ -35,7 +36,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "1.0.49"
 time = { version = "0.3.29", features = ["serde"] }
-tokio = { version = "1.32.0", features = ["sync", "rt"] }
+tokio = { version = "1.32.0", features = ["sync"] }
 tower-cookies = "0.9.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
@@ -78,23 +79,23 @@ required-features = ["axum-core", "redis-store"]
 
 [[example]]
 name = "mongodb-store"
-required-features = ["axum-core", "mongodb-store"]
+required-features = ["axum-core", "mongodb-store", "tokio-rt"]
 
 [[example]]
 name = "sqlite-store"
-required-features = ["axum-core", "sqlite-store"]
+required-features = ["axum-core", "sqlite-store", "tokio-rt"]
 
 [[example]]
 name = "postgres-store"
-required-features = ["axum-core", "postgres-store"]
+required-features = ["axum-core", "postgres-store", "tokio-rt"]
 
 [[example]]
 name = "moka-postgres-store"
-required-features = ["axum-core", "postgres-store", "moka-store"]
+required-features = ["axum-core", "postgres-store", "moka-store", "tokio-rt"]
 
 [[example]]
 name = "mysql-store"
-required-features = ["axum-core", "mysql-store"]
+required-features = ["axum-core", "mysql-store", "tokio-rt"]
 
 [[example]]
 name = "strongly-typed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ sqlite-store = ["sqlx/sqlite", "sqlx-store"]
 postgres-store = ["sqlx/postgres", "sqlx-store"]
 mysql-store = ["sqlx/mysql", "sqlx-store"]
 moka-store = ["moka"]
-#tokio = ["dep:tokio"]
 
 [dependencies]
 async-trait = "0.1.73"
@@ -36,13 +35,11 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "1.0.49"
 time = { version = "0.3.29", features = ["serde"] }
+tokio = { version = "1.32.0", features = ["sync", "rt"] }
 tower-cookies = "0.9.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
-
-# This is temporarily required; move back to optional once session lock can be removed.
-tokio = { version = "1.32.0", features = ["full"] }
 
 axum-core = { optional = true, version = "0.3.4" }
 fred = { optional = true, version = "6.3.2" }
@@ -59,8 +56,8 @@ moka = { optional = true, version = "0.12.0", features = ["future"] }
 [dev-dependencies]
 axum = "0.6.20"
 hyper = "0.14.27"
-tokio = { version = "1.32.0", features = ["full"] }
 tower = "0.4.13"
+tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 
 [package.metadata.docs.rs]
@@ -81,23 +78,23 @@ required-features = ["axum-core", "redis-store"]
 
 [[example]]
 name = "mongodb-store"
-required-features = ["axum-core", "mongodb-store", "tokio"]
+required-features = ["axum-core", "mongodb-store"]
 
 [[example]]
 name = "sqlite-store"
-required-features = ["axum-core", "sqlite-store", "tokio"]
+required-features = ["axum-core", "sqlite-store"]
 
 [[example]]
 name = "postgres-store"
-required-features = ["axum-core", "postgres-store", "tokio"]
+required-features = ["axum-core", "postgres-store"]
 
 [[example]]
 name = "moka-postgres-store"
-required-features = ["axum-core", "postgres-store", "moka-store", "tokio"]
+required-features = ["axum-core", "postgres-store", "moka-store"]
 
 [[example]]
 name = "mysql-store"
-required-features = ["axum-core", "mysql-store", "tokio"]
+required-features = ["axum-core", "mysql-store"]
 
 [[example]]
 name = "strongly-typed"

--- a/src/mongodb_store.rs
+++ b/src/mongodb_store.rs
@@ -94,6 +94,7 @@ impl MongoDBStore {
     /// );
     /// # })
     /// ```
+    #[cfg(feature = "tokio-rt")]
     pub async fn continuously_delete_expired(
         self,
         period: tokio::time::Duration,

--- a/src/mongodb_store.rs
+++ b/src/mongodb_store.rs
@@ -62,7 +62,6 @@ impl MongoDBStore {
         }
     }
 
-    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired documents
     /// and then waiting for the specified period before deleting again.
     ///

--- a/src/sqlx_store/mysql_store.rs
+++ b/src/sqlx_store/mysql_store.rs
@@ -111,6 +111,7 @@ impl MySqlStore {
     /// );
     /// # })
     /// ```
+    #[cfg(feature = "tokio-rt")]
     pub async fn continuously_delete_expired(
         self,
         period: tokio::time::Duration,

--- a/src/sqlx_store/mysql_store.rs
+++ b/src/sqlx_store/mysql_store.rs
@@ -79,7 +79,6 @@ impl MySqlStore {
         Ok(())
     }
 
-    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired rows and
     /// then waiting for the specified period before deleting again.
     ///

--- a/src/sqlx_store/postgres_store.rs
+++ b/src/sqlx_store/postgres_store.rs
@@ -91,7 +91,6 @@ impl PostgresStore {
         Ok(())
     }
 
-    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired rows and
     /// then waiting for the specified period before deleting again.
     ///

--- a/src/sqlx_store/postgres_store.rs
+++ b/src/sqlx_store/postgres_store.rs
@@ -123,6 +123,7 @@ impl PostgresStore {
     /// );
     /// # })
     /// ```
+    #[cfg(feature = "tokio-rt")]
     pub async fn continuously_delete_expired(
         self,
         period: tokio::time::Duration,

--- a/src/sqlx_store/sqlite_store.rs
+++ b/src/sqlx_store/sqlite_store.rs
@@ -109,6 +109,7 @@ impl SqliteStore {
     /// );
     /// # })
     /// ```
+    #[cfg(feature = "tokio-rt")]
     pub async fn continuously_delete_expired(
         self,
         period: tokio::time::Duration,

--- a/src/sqlx_store/sqlite_store.rs
+++ b/src/sqlx_store/sqlite_store.rs
@@ -78,7 +78,6 @@ impl SqliteStore {
         Ok(())
     }
 
-    //#[cfg(feature = "tokio")]
     /// This function will keep running indefinitely, deleting expired rows and
     /// then waiting for the specified period before deleting again.
     ///


### PR DESCRIPTION
This moves to a pattern of tracking loaded sessions via a hash set. By doing so, we can share sessions concurrently. In other words, we no longer need a lock to protect the session for the duration of the request and instead are able to share sessions between concurrent tasks.

Why do we need this at all? A data race can otherwise occur when a session has been loaded but its modifications have not been stored. For instance, another task may load the session from the store in the meantime and this load will overwrite pending modifications as it will effectively replace the session in memory.

One solution to this problem is to lock the request, as we've done in a stopgap capacity. This unscalable at present and even when refined, i.e. to lock per session as opposed for all sessions, limits concurrency over the session itself. In practice, sessions can only be operated on serially and are not available concurrently.

A more flexible approach is implemented here, allowing for concurrent memory access by limiting loads from the store to situations where no session exists in the loaded set. Put another way, sessions are tracked such that they can be used instead of loading from the store thus ensuring that pending modifications are not lost by a load.

See #36 for more details about the stopgap locking behavior; this replaces that approach altogether.