### PR TITLE
Add a customizable diesel backed session store

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
   REDIS_URL: redis://localhost:6379/1
   MONGODB_URL: mongodb://localhost:27017
   POSTGRES_URL: postgres://postgres:postgres@localhost:5432
-  MYSQL_URL: mysql://root@localhost:3306/public
+  MYSQL_URL: mysql://root@127.0.0.1:3306/public
 
 jobs:
   check:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,6 +124,18 @@ jobs:
             features: moka-store,sqlite-store
             docker: false
 
+          - store: mysql_store
+            features: __diesel_mysql
+            docker: true
+
+          - store: postgres_store
+            features: __diesel_postgres
+            docker: true
+
+          - store: diesel_store
+            features: diesel-store
+            docker: false
+
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ tower = "0.4.13"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 reqwest = "0.11.22"
+diesel = {default-features = false, version = "2.1", features = ["sqlite"] }
+libsqlite3-sys = { version = "0.26", features = ["bundled"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.67.1"
 
 [features]
-default = ["axum-core", "memory-store"]
+default = ["axum-core", "memory-store", "diesel-store"]
 memory-store = []
 redis-store = ["fred", "rmp-serde"]
 mongodb-store = ["mongodb", "bson"]
@@ -23,7 +23,8 @@ sqlite-store = ["sqlx/sqlite", "sqlx-store"]
 postgres-store = ["sqlx/postgres", "sqlx-store"]
 mysql-store = ["sqlx/mysql", "sqlx-store"]
 moka-store = ["moka"]
-tokio-rt = ["tokio/rt"]
+tokio-rt = ["tokio/rt", "tokio/time"]
+diesel-store = ["dep:diesel", "tokio/rt", "rmp-serde"]
 
 [dependencies]
 async-trait = "0.1.73"
@@ -54,6 +55,7 @@ sqlx = { optional = true, version = "0.7.2", features = [
 ] }
 tokio = { optional = true, version = "1.32.0", default-features = false }
 moka = { optional = true, version = "0.12.0", features = ["future"] }
+diesel = { optional = true, default-features = false, version = "2.1", features = ["r2d2", "time"] }
 
 [dev-dependencies]
 axum = "0.6.20"
@@ -102,3 +104,12 @@ required-features = ["axum-core", "mysql-store", "tokio-rt"]
 [[example]]
 name = "strongly-typed"
 required-features = ["axum-core", "memory-store"]
+
+[[example]]
+name = "diesel-store"
+required-features = ["axum-core", "diesel-store", "diesel/sqlite", "tokio-rt"]
+
+
+[[example]]
+name = "diesel-store-with-custom-table"
+required-features = ["axum-core", "diesel-store", "diesel/sqlite", "tokio-rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ moka-store = ["moka"]
 tokio-rt = ["tokio/rt", "tokio/time"]
 diesel-store = ["dep:diesel", "tokio/rt", "rmp-serde"]
 
+__diesel_postgres = ["diesel-store", "diesel/postgres"]
+__diesel_mysql = ["diesel-store", "diesel/mysql"]
+
 [dependencies]
 async-trait = "0.1.73"
 dashmap = "5.5.3"

--- a/examples/diesel-store-with-custom-table.rs
+++ b/examples/diesel-store-with-custom-table.rs
@@ -1,0 +1,117 @@
+use std::net::SocketAddr;
+
+use axum::{
+    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
+};
+use diesel::{
+    connection::SimpleConnection,
+    prelude::*,
+    r2d2::{ConnectionManager, Pool},
+};
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+use time::Duration;
+use tower::ServiceBuilder;
+use tower_sessions::{
+    diesel_store::{DieselStore, DieselStoreError, SessionTable},
+    Session, SessionManagerLayer,
+};
+
+const COUNTER_KEY: &str = "counter";
+
+#[derive(Serialize, Deserialize, Default)]
+struct Counter(usize);
+
+diesel::table! {
+    /// The session table used by default by the diesel-store implemenattion
+    my_sessions {
+        /// `id` column, contains a session id
+        id -> Text,
+        /// `expiration_time` column, contains an optional expiration timestamp
+        expiration_time -> Nullable<Timestamp>,
+        /// `data` column, contains serialized session data
+        data -> Binary,
+    }
+}
+
+impl SessionTable<SqliteConnection> for self::my_sessions::table {
+    type ExpirationTime = self::my_sessions::expiration_time;
+
+    fn insert(
+        conn: &mut SqliteConnection,
+        session_record: &tower_sessions::session::SessionRecord,
+    ) -> Result<(), DieselStoreError> {
+        diesel::insert_into(my_sessions::table)
+            .values((
+                my_sessions::id.eq(session_record.id().to_string()),
+                my_sessions::expiration_time.eq(session_record
+                    .expiration_time()
+                    .map(|t| time::PrimitiveDateTime::new(t.date(), t.time()))),
+                my_sessions::data.eq(rmp_serde::to_vec(&session_record.data())?),
+            ))
+            .execute(conn)?;
+        Ok(())
+    }
+
+    fn migrate(conn: &mut SqliteConnection) -> Result<(), DieselStoreError> {
+        // or create the table via normal diesel migrations on startup and leave that
+        // function empty
+        conn.batch_execute(
+            "CREATE TABLE `my_sessions` (`id` TEXT PRIMARY KEY NOT NULL, `expiration_time` TEXT \
+             NULL, `data` BLOB NOT NULL);",
+        )?;
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(ConnectionManager::<SqliteConnection>::new(":memory:"))
+        .unwrap();
+    let session_store = DieselStore::with_table(my_sessions::table, pool);
+    session_store.migrate().await?;
+
+    let deletion_task = tokio::task::spawn(
+        session_store
+            .clone()
+            .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
+    );
+
+    let session_service = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(|_: BoxError| async {
+            StatusCode::BAD_REQUEST
+        }))
+        .layer(
+            SessionManagerLayer::new(session_store)
+                .with_secure(false)
+                .with_max_age(Duration::seconds(10)),
+        );
+
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(session_service);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    deletion_task.await??;
+
+    Ok(())
+}
+
+async fn handler(session: Session) -> impl IntoResponse {
+    let counter: Counter = session
+        .get(COUNTER_KEY)
+        .expect("Could not deserialize.")
+        .unwrap_or_default();
+
+    session
+        .insert(COUNTER_KEY, counter.0 + 1)
+        .expect("Could not serialize.");
+
+    format!("Current count: {}", counter.0)
+}

--- a/examples/diesel-store.rs
+++ b/examples/diesel-store.rs
@@ -1,0 +1,71 @@
+use std::net::SocketAddr;
+
+use axum::{
+    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
+};
+use diesel::{
+    prelude::*,
+    r2d2::{ConnectionManager, Pool},
+};
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+use time::Duration;
+use tower::ServiceBuilder;
+use tower_sessions::{diesel_store::DieselStore, Session, SessionManagerLayer};
+
+const COUNTER_KEY: &str = "counter";
+
+#[derive(Serialize, Deserialize, Default)]
+struct Counter(usize);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(ConnectionManager::<SqliteConnection>::new(":memory:"))
+        .unwrap();
+    let session_store = DieselStore::new(pool);
+    session_store.migrate().await?;
+
+    let deletion_task = tokio::task::spawn(
+        session_store
+            .clone()
+            .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
+    );
+
+    let session_service = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(|_: BoxError| async {
+            StatusCode::BAD_REQUEST
+        }))
+        .layer(
+            SessionManagerLayer::new(session_store)
+                .with_secure(false)
+                .with_max_age(Duration::seconds(10)),
+        );
+
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(session_service);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    deletion_task.await??;
+
+    Ok(())
+}
+
+async fn handler(session: Session) -> impl IntoResponse {
+    let counter: Counter = session
+        .get(COUNTER_KEY)
+        .expect("Could not deserialize.")
+        .unwrap_or_default();
+
+    session
+        .insert(COUNTER_KEY, counter.0 + 1)
+        .expect("Could not serialize.");
+
+    format!("Current count: {}", counter.0)
+}

--- a/src/diesel_store.rs
+++ b/src/diesel_store.rs
@@ -149,7 +149,18 @@ where
         } else {
             qb.push_sql("BLOB NOT NULL);");
         }
-        conn.batch_execute(&qb.finish())?;
+        let r = conn.batch_execute(&qb.finish());
+        if !matches!(
+            r,
+            Err(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            ))
+        ) {
+            // ignore unique violations because of postgres issues:
+            // https://www.postgresql.org/message-id/CA+TgmoZAdYVtwBfp1FL2sMZbiHCWT4UPrzRLNnX1Nb30Ku3-gg@mail.gmail.com
+            r?;
+        }
         Ok(())
     }
 }

--- a/src/diesel_store.rs
+++ b/src/diesel_store.rs
@@ -1,0 +1,398 @@
+//! A session store backed by a diesel connection pool
+use std::marker::PhantomData;
+
+use diesel::{
+    associations::HasTable,
+    backend::Backend,
+    deserialize::FromStaticSqlRow,
+    dsl::{And, IsNull, Lt, Or},
+    expression::{AsExpression, ValidGrouping},
+    expression_methods::ExpressionMethods,
+    helper_types::{Eq, Filter, Gt, IntoBoxed, SqlTypeOf},
+    prelude::{BoolExpressionMethods, Insertable, Queryable},
+    query_builder::{
+        AsQuery, DeleteStatement, InsertStatement, IntoUpdateTarget, QueryBuilder, QueryFragment,
+    },
+    query_dsl::methods::{BoxedDsl, ExecuteDsl, FilterDsl, LimitDsl, LoadQuery},
+    r2d2::{ConnectionManager, ManageConnection, Pool, R2D2Connection},
+    sql_types::{Binary, Bool, Nullable, SingleValue, SqlType, Text, Timestamp},
+    BoxableExpression, Column, Expression, OptionalExtension, QueryDsl, RunQueryDsl,
+    SelectableExpression, Table,
+};
+
+use crate::SessionStore;
+
+/// An error type for diesel stores
+#[derive(thiserror::Error, Debug)]
+pub enum DieselStoreError {
+    /// A pool related error
+    #[error("Pool Error: {0}")]
+    R2D2Error(#[from] diesel::r2d2::PoolError),
+    /// A diesel related error
+    #[error("Diesel Error: {0}")]
+    DieselError(#[from] diesel::result::Error),
+    /// Failed to join a blocking tokio task
+    #[error("Failed to join task: {0}")]
+    TokioJoinERror(#[from] tokio::task::JoinError),
+    /// A variant to map `rmp_serde` encode errors.
+    #[error("Failed to serialize session data: {0}")]
+    SerializationError(#[from] rmp_serde::encode::Error),
+}
+
+/// A Diesel session store
+#[derive(Debug)]
+pub struct DieselStore<C: R2D2Connection + 'static, T = self::sessions::table> {
+    p: PhantomData<T>,
+    pool: diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<C>>,
+}
+
+// custom impl as we don't want to have `Clone bounds on the types
+impl<C: R2D2Connection + 'static, T> Clone for DieselStore<C, T> {
+    fn clone(&self) -> Self {
+        Self {
+            p: self.p,
+            pool: self.pool.clone(),
+        }
+    }
+}
+
+diesel::table! {
+    /// The session table used by default by the diesel-store implemenattion
+    sessions {
+        /// `id` column, contains a session id
+        id -> Text,
+        /// `expiration_time` column, contains an optional expiration timestamp
+        expiration_time -> Nullable<Timestamp>,
+        /// `data` column, contains serialized session data
+        data -> Binary,
+    }
+}
+
+/// An extension trait for customizing the session table used by the
+/// [`DieselStore`]
+///
+/// Implement this for your `table` type if you want to use a custom table
+/// definition
+pub trait SessionTable<C>: Copy + Send + Sync + AsQuery + HasTable<Table = Self> + Table
+where
+    C: R2D2Connection,
+{
+    /// the `expiration_time` column of your table
+    type ExpirationTime: Column<SqlType = Nullable<Timestamp>>
+        + Default
+        + ValidGrouping<(), IsAggregate = diesel::expression::is_aggregate::No>
+        + Send
+        + 'static;
+
+    /// Insert a new record into the sessions table
+    fn insert(
+        conn: &mut C,
+        session_record: &crate::session::SessionRecord,
+    ) -> Result<(), DieselStoreError>;
+
+    /// An function to optionally create the session table in the database
+    fn migrate(_conn: &mut C) -> Result<(), DieselStoreError> {
+        Ok(())
+    }
+}
+
+impl<C> SessionTable<C> for self::sessions::table
+where
+    <C::Backend as Backend>::QueryBuilder: Default,
+    C: diesel::r2d2::R2D2Connection,
+    InsertStatement<
+        Self,
+        <(
+            Eq<sessions::id, String>,
+            Eq<sessions::expiration_time, Option<time::PrimitiveDateTime>>,
+            Eq<sessions::data, Vec<u8>>,
+        ) as Insertable<Self>>::Values,
+    >: ExecuteDsl<C>,
+{
+    type ExpirationTime = self::sessions::expiration_time;
+
+    fn insert(
+        conn: &mut C,
+        session_record: &crate::session::SessionRecord,
+    ) -> Result<(), DieselStoreError> {
+        diesel::insert_into(sessions::table)
+            .values((
+                sessions::id.eq(session_record.id().to_string()),
+                sessions::expiration_time.eq(session_record
+                    .expiration_time()
+                    .map(|t| time::PrimitiveDateTime::new(t.date(), t.time()))),
+                sessions::data.eq(rmp_serde::to_vec(&session_record.data())?),
+            ))
+            .execute(conn)?;
+        Ok(())
+    }
+
+    fn migrate(conn: &mut C) -> Result<(), DieselStoreError> {
+        let mut qb = <C::Backend as Backend>::QueryBuilder::default();
+        let connection_type = std::any::type_name::<C::Backend>();
+        qb.push_sql("CREATE TABLE IF NOT EXISTS ");
+        qb.push_identifier("sessions")?;
+        qb.push_sql("( ");
+        qb.push_identifier(sessions::id::NAME)?;
+        // we need these hacks to not depend on all diesel backends on the same time
+        if connection_type.ends_with("Mysql") {
+            qb.push_sql(" CHAR(36) PRIMARY KEY NOT NULL, ");
+        } else {
+            qb.push_sql(" TEXT PRIMARY KEY NOT NULL, ");
+        }
+        qb.push_identifier(sessions::expiration_time::NAME)?;
+        qb.push_sql(" TIMESTAMP NULL, ");
+        qb.push_identifier(sessions::data::NAME)?;
+        // we need these hacks to not depend on all diesel backends on the same time
+        if connection_type.ends_with("Pg") {
+            qb.push_sql(" BYTEA NOT NULL);");
+        } else {
+            qb.push_sql("BLOB NOT NULL);");
+        }
+        conn.batch_execute(&qb.finish())?;
+        Ok(())
+    }
+}
+
+impl<C> DieselStore<C>
+where
+    C: R2D2Connection,
+{
+    /// Create a new diesel store with a provided connection pool.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use diesel::{
+    ///     prelude::*,
+    ///     r2d2::{ConnectionManager, Pool},
+    /// };
+    /// use tower_sessions::diesel_store::DieselStore;
+    ///
+    /// let pool = Pool::builder()
+    ///     .build(ConnectionManager::<SqliteConnection>::new(":memory:"))
+    ///     .unwrap();
+    /// let session_store = DieselStore::new(pool);
+    /// ```
+    pub fn new(pool: diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<C>>) -> Self {
+        Self {
+            pool,
+            p: PhantomData,
+        }
+    }
+}
+
+impl<C, T> DieselStore<C, T>
+where
+    C: R2D2Connection,
+    T: SessionTable<C>,
+    T: FilterDsl<Box<dyn BoxableExpression<T, C::Backend, SqlType = Nullable<Bool>>>>,
+    Filter<T, Box<dyn BoxableExpression<T, C::Backend, SqlType = Nullable<Bool>>>>: IntoUpdateTarget,
+    DeleteStatement<
+        <Filter<T, Box<dyn BoxableExpression<T, C::Backend, SqlType = Nullable<Bool>>>> as HasTable>::Table,
+        <Filter<T, Box<dyn BoxableExpression<T, C::Backend, SqlType = Nullable<Bool>>>> as IntoUpdateTarget>::WhereClause,
+    >: ExecuteDsl<C>,
+   Lt<T::ExpirationTime, diesel::dsl::now>: QueryFragment<C::Backend> + SelectableExpression<T> + Expression<SqlType = Nullable<Bool>>,
+{
+    /// Create a new diesel store with a provided connection pool.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use tower_sessions::diesel_store::{DieselStore};
+    /// use diesel::prelude::*;
+    /// use diesel::r2d2::{Pool, ConnectionManager};
+    ///
+    /// let pool = Pool::builder().build(ConnectionManager::<SqliteConnection>::new(":memory:")).unwrap();
+    /// let session_store = DieselStore::with_table(tower_sessions::diesel_store::sessions::table, pool);
+    /// ```
+    pub fn with_table(
+        _table: T,
+        pool: diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<C>>,
+    ) -> Self {
+        Self {
+            pool,
+            p: PhantomData,
+        }
+    }
+
+    /// Migrate the session schema.
+    pub async fn migrate(&self) -> Result<(), DieselStoreError> {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = pool.get()?;
+            T::migrate(&mut conn)?;
+            Ok::<_, DieselStoreError>(())
+        })
+        .await??;
+        Ok(())
+    }
+
+    #[cfg(feature = "tokio-rt")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-rt")))]
+    async fn delete_expired(&self) -> Result<(), DieselStoreError> {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = pool.get()?;
+            let filter: Box<dyn BoxableExpression<T, C::Backend, SqlType = Nullable<Bool>>> = Box::new(T::ExpirationTime::default().lt(diesel::dsl::now)) as Box<_>;
+            diesel::delete(T::table().filter(filter))
+                .execute(&mut conn)?;
+            Ok::<_, DieselStoreError>(())
+        })
+        .await??;
+        Ok(())
+    }
+
+    /// This function will keep running indefinitely, deleting expired rows and
+    /// then waiting for the specified period before deleting again.
+    ///
+    /// Generally this will be used as a task, for example via
+    /// `tokio::task::spawn`.
+    ///
+    /// # Arguments
+    ///
+    /// * `period` - The interval at which expired rows should be deleted.
+    ///
+    /// # Errors
+    ///
+    /// This function returns a `Result` that contains an error of type
+    /// `sqlx::Error` if the deletion operation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use tower_sessions::diesel_store::DieselStore;
+    /// use diesel::r2d2::{ConnectionManager, Pool};
+    /// use diesel::prelude::*;
+    ///
+    /// let pool = Pool::builder().build(ConnectionManager::<SqliteConnection>::new(":memory:")).unwrap();
+    /// let session_store = DieselStore::new(pool);
+    ///
+    /// # tokio_test::block_on(async {
+    /// tokio::task::spawn(
+    ///     session_store
+    ///         .clone()
+    ///         .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
+    /// );
+    /// # })
+    /// ```
+    #[cfg(feature = "tokio-rt")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-rt")))]
+    pub async fn continuously_delete_expired(
+        self,
+        period: tokio::time::Duration,
+    ) -> Result<(), DieselStoreError> {
+        let mut interval = tokio::time::interval(period);
+        loop {
+            self.delete_expired().await?;
+            interval.tick().await;
+        }
+    }
+}
+
+impl<DB> Queryable<(Text, Nullable<Timestamp>, Binary), DB> for crate::session::Session
+where
+    DB: Backend,
+    (String, Option<time::PrimitiveDateTime>, Vec<u8>):
+        FromStaticSqlRow<(Text, Nullable<Timestamp>, Binary), DB>,
+{
+    type Row = (String, Option<time::PrimitiveDateTime>, Vec<u8>);
+
+    fn build((id, expiration_time, data): Self::Row) -> diesel::deserialize::Result<Self> {
+        let expiration_time = expiration_time.map(|t| t.assume_utc());
+        let session_id = crate::session::SessionId::try_from(id)?;
+        let session_record = crate::session::SessionRecord::new(
+            session_id,
+            expiration_time,
+            rmp_serde::from_slice(&data)?,
+        );
+        Ok(session_record.into())
+    }
+}
+
+#[async_trait::async_trait]
+impl<C, T> SessionStore for DieselStore<C, T>
+where
+    T: SessionTable<C> + 'static,
+    String: AsExpression<SqlTypeOf<T::PrimaryKey>>,
+    T::PrimaryKey: Default,
+    <T::PrimaryKey as Expression>::SqlType: SqlType + SingleValue,
+    DeleteStatement<T, Eq<T::PrimaryKey, String>>: ExecuteDsl<C>,
+    T: FilterDsl<Eq<T::PrimaryKey, String>> + BoxedDsl<'static, C::Backend>,
+    IntoBoxed<'static, T, C::Backend>: LimitDsl<Output = IntoBoxed<'static, T, C::Backend>>,
+    IntoBoxed<'static, T, C::Backend>: FilterDsl<
+        And<
+            Eq<T::PrimaryKey, String>,
+            Or<IsNull<T::ExpirationTime>, Gt<T::ExpirationTime, diesel::dsl::now>, Nullable<Bool>>,
+            Nullable<Bool>,
+        >,
+        Output = IntoBoxed<'static, T, C::Backend>,
+    >,
+    Filter<T, Eq<T::PrimaryKey, String>>: IntoUpdateTarget,
+    DeleteStatement<
+        <Filter<T, Eq<T::PrimaryKey, String>> as HasTable>::Table,
+        <Filter<T, Eq<T::PrimaryKey, String>> as IntoUpdateTarget>::WhereClause,
+    >: ExecuteDsl<C>,
+    Eq<T::PrimaryKey, String>: BoolExpressionMethods<SqlType = Bool>,
+    for<'a> IntoBoxed<'static, T, C::Backend>: LoadQuery<'a, C, crate::Session>,
+    Pool<ConnectionManager<C>>: Clone,
+    ConnectionManager<C>: ManageConnection<Connection = C>,
+    C: R2D2Connection,
+{
+    type Error = DieselStoreError;
+
+    async fn save(&self, session_record: &crate::SessionRecord) -> Result<(), Self::Error> {
+        let pool = self.pool.clone();
+        let record = session_record.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn: &mut diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<C>> =
+                &mut pool.get()?;
+            T::insert(conn, &record)
+        })
+        .await??;
+        Ok(())
+    }
+
+    async fn load(
+        &self,
+        session_id: &crate::session::SessionId,
+    ) -> Result<Option<crate::Session>, Self::Error> {
+        let session_id = session_id.to_string();
+        let pool = self.pool.clone();
+        let res = tokio::task::spawn_blocking(move || {
+            let conn: &mut diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<C>> =
+                &mut pool.get()?;
+
+            let q = T::table()
+                .into_boxed()
+                .limit(1)
+                .filter(
+                    T::PrimaryKey::default().eq(session_id.to_string()).and(
+                        T::ExpirationTime::default()
+                            .is_null()
+                            .or(T::ExpirationTime::default().gt(diesel::dsl::now)),
+                    ),
+                )
+                .get_result(conn)
+                .optional()?;
+            Ok::<_, DieselStoreError>(q)
+        })
+        .await??;
+
+        Ok(res)
+    }
+
+    async fn delete(&self, session_id: &crate::session::SessionId) -> Result<(), Self::Error> {
+        let session_id = session_id.to_string();
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn: &mut diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<C>> =
+                &mut pool.get()?;
+            diesel::delete(T::table().filter(T::PrimaryKey::default().eq(session_id.to_string())))
+                .execute(conn)?;
+            Ok::<_, DieselStoreError>(())
+        })
+        .await??;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,6 +531,10 @@ mod mongodb_store;
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlx-store")))]
 mod sqlx_store;
 
+#[cfg(feature = "diesel-store")]
+#[cfg_attr(docsrs, doc(cfg(feature = "diesel-store")))]
+pub mod diesel_store;
+
 pub mod cookie_config;
 pub mod service;
 pub mod session;

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -118,6 +118,93 @@ mod mysql_store_tests {
     route_tests!(app);
 }
 
+#[cfg(all(test, feature = "axum-core", feature = "diesel-store"))]
+mod diesel_sqlite_store_tests {
+    use axum::Router;
+    use diesel::prelude::*;
+    use diesel::r2d2::{ConnectionManager, Pool};
+    use tower_sessions::diesel_store::DieselStore;
+    use tower_sessions::SessionManagerLayer;
+
+    use crate::common::build_app;
+
+    async fn app(max_age: Option<Duration>) -> Router {
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(ConnectionManager::<SqliteConnection>::new(":memory:"))
+            .unwrap();
+        let session_store = DieselStore::new(pool);
+        session_store.migrate().await.unwrap();
+        let session_manager = SessionManagerLayer::new(session_store).with_secure(true);
+
+        build_app(session_manager, max_age)
+    }
+
+    route_tests!(app);
+}
+
+#[cfg(all(
+    test,
+    feature = "axum-core",
+    feature = "diesel-store",
+    feature = "__diesel_postgres"
+))]
+mod diesel_pg_store_tests {
+    use axum::Router;
+    use diesel::prelude::*;
+    use diesel::r2d2::{ConnectionManager, Pool};
+    use tower_sessions::diesel_store::DieselStore;
+    use tower_sessions::SessionManagerLayer;
+
+    use crate::common::build_app;
+
+    async fn app(max_age: Option<Duration>) -> Router {
+        let database_url = std::option_env!("POSTGRES_URL").unwrap();
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(ConnectionManager::<PgConnection>::new(database_url))
+            .unwrap();
+        let session_store = DieselStore::new(pool);
+        session_store.migrate().await.unwrap();
+        let session_manager = SessionManagerLayer::new(session_store).with_secure(true);
+
+        build_app(session_manager, max_age)
+    }
+
+    route_tests!(app);
+}
+
+#[cfg(all(
+    test,
+    feature = "axum-core",
+    feature = "diesel-store",
+    feature = "__diesel_mysql"
+))]
+mod diesel_mysql_store_tests {
+    use axum::Router;
+    use diesel::prelude::*;
+    use diesel::r2d2::{ConnectionManager, Pool};
+    use tower_sessions::diesel_store::DieselStore;
+    use tower_sessions::SessionManagerLayer;
+
+    use crate::common::build_app;
+
+    async fn app(max_age: Option<Duration>) -> Router {
+        let database_url = std::option_env!("MYSQL_URL").unwrap();
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(ConnectionManager::<MysqlConnection>::new(database_url))
+            .unwrap();
+        let session_store = DieselStore::new(pool);
+        session_store.migrate().await.unwrap();
+        let session_manager = SessionManagerLayer::new(session_store).with_secure(true);
+
+        build_app(session_manager, max_age)
+    }
+
+    route_tests!(app);
+}
+
 #[cfg(all(test, feature = "axum-core", feature = "mongodb-store"))]
 mod mongodb_store_tests {
     use axum::Router;


### PR DESCRIPTION
This commit adds a custom diesel backed session store. It abstracts over different database backends and allows to customize the used session table.

This partially addresses #26 (the diesel part, not the diesel-async part)