### PR TITLE
remove loaded sessions when unneeded

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           rustup toolchain install stable --profile minimal
+          cargo install cargo-tarpaulin
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,6 +65,16 @@ jobs:
       - name: Run doc tests
         run: |
           cargo test --all-features --doc
+      - name: Generate code coverage
+        run: |
+          output_dir="./coverage/doc"
+          cargo tarpaulin -olcov --doc  --output-dir $output_dir
+          mkdir -p coverage-artifacts
+          mv $output_dir coverage-artifacts/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-artifacts
+          path: coverage-artifacts
 
   test-concurrency:
     needs: check
@@ -130,7 +140,7 @@ jobs:
       - name: Generate code coverage
         run: |
           output_dir="./coverage/${{ matrix.store }}_${{ matrix.features }}"
-          cargo tarpaulin -olcov --features ${{ matrix.features }} --output-dir $output_dir
+          cargo tarpaulin -olcov --test integration-tests --features ${{ matrix.features }} --output-dir $output_dir
           mkdir -p coverage-artifacts
           mv $output_dir coverage-artifacts/
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          rustup toolchain install stable --profile minimal
+          rustup toolchain install nightly --profile minimal
           cargo install cargo-tarpaulin
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
@@ -150,7 +150,9 @@ jobs:
           path: coverage-artifacts
 
   upload-coverage:
-    needs: test-integration
+    needs:
+      - test-docs
+      - test-integration
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,18 @@ jobs:
         run: |
           cargo test --all-features --doc
 
+  test-concurrency:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: Run doc tests
+        run: |
+          cargo test --test concurrency-tests
+
   test-integration:
     needs: check
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,12 +70,12 @@ jobs:
         run: |
           output_dir="./coverage/doc"
           cargo tarpaulin -olcov --doc  --output-dir $output_dir
-          mkdir -p coverage-artifacts
-          mv $output_dir coverage-artifacts/
+          mkdir -p coverage-artifacts/doc
+          mv $output_dir coverage-artifacts/doc/
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage-artifacts
-          path: coverage-artifacts
+          name: coverage-artifacts-doc
+          path: coverage-artifacts/doc
 
   test-concurrency:
     needs: check
@@ -142,12 +142,12 @@ jobs:
         run: |
           output_dir="./coverage/${{ matrix.store }}_${{ matrix.features }}"
           cargo tarpaulin -olcov --test integration-tests --features ${{ matrix.features }} --output-dir $output_dir
-          mkdir -p coverage-artifacts
-          mv $output_dir coverage-artifacts/
+          mkdir -p coverage-artifacts/integration
+          mv $output_dir coverage-artifacts/integration/
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage-artifacts
-          path: coverage-artifacts
+          name: coverage-artifacts-integration
+          path: coverage-artifacts/integration
 
   upload-coverage:
     needs:
@@ -155,13 +155,21 @@ jobs:
       - test-integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download Docs Coverage
+        uses: actions/download-artifact@v2
         with:
-          name: coverage-artifacts
-          path: coverage-artifacts
-      - run: |
-          mkdir ./coverage
-          mv coverage-artifacts/* ./coverage/
+          name: coverage-artifacts-doc
+          path: coverage-artifacts-doc
+      - name: Download Integration Coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-artifacts-integration
+          path: coverage-artifacts-integration
+      - name: Combine Coverage Data
+        run: |
+          mkdir -p ./coverage
+          mv coverage-artifacts-doc/* ./coverage/
+          mv coverage-artifacts-integration/* ./coverage/
           ls -la ./coverage
       - name: Upload all coverage data to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
       - run: |
           rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - name: Run doc tests
+      - name: Run concurrency tests
         run: |
           cargo test --test concurrency-tests
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ hyper = "0.14.27"
 tower = "0.4.13"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
+reqwest = "0.11.22"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/counter-concurrent.rs
+++ b/examples/counter-concurrent.rs
@@ -59,5 +59,5 @@ async fn handler(session: Session) -> impl IntoResponse {
         new_counter = Counter(counter.0 + 1);
     }
 
-    format!("Current count: {}", counter.0)
+    format!("{}", counter.0)
 }

--- a/examples/counter-concurrent.rs
+++ b/examples/counter-concurrent.rs
@@ -1,0 +1,63 @@
+use std::net::SocketAddr;
+
+use axum::{
+    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
+};
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+use time::Duration;
+use tower::ServiceBuilder;
+use tower_sessions::{MemoryStore, Session, SessionManagerLayer};
+
+const COUNTER_KEY: &str = "counter";
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+struct Counter(usize);
+
+#[tokio::main]
+async fn main() {
+    let session_store = MemoryStore::default();
+    let session_service = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(|_: BoxError| async {
+            StatusCode::BAD_REQUEST
+        }))
+        .layer(
+            SessionManagerLayer::new(session_store)
+                .with_secure(false)
+                .with_max_age(Duration::days(1)),
+        );
+
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(session_service);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn handler(session: Session) -> impl IntoResponse {
+    let mut counter: Counter = session
+        .get(COUNTER_KEY)
+        .expect("Could not deserialize.")
+        .unwrap_or_else(|| {
+            let counter = Counter::default();
+            session
+                .insert(COUNTER_KEY, counter.clone())
+                .expect("Could not serialize.");
+            counter
+        });
+
+    let mut new_counter = Counter(counter.0 + 1);
+    while let Ok(false) = session.replace_if_equal(COUNTER_KEY, counter.clone(), new_counter) {
+        counter = session
+            .get(COUNTER_KEY)
+            .expect("Could not deserialize.")
+            .unwrap();
+        new_counter = Counter(counter.0 + 1);
+    }
+
+    format!("Current count: {}", counter.0)
+}

--- a/tests/concurrency-tests.rs
+++ b/tests/concurrency-tests.rs
@@ -32,7 +32,7 @@ fn start_example_binary() -> ChildGuard {
         .spawn()
         .expect("Failed to start example binary");
 
-    std::thread::sleep(Duration::from_secs(2)); // Wait for the example binary to initialize.
+    std::thread::sleep(Duration::from_secs(5)); // Wait for the example binary to initialize.
 
     ChildGuard { child }
 }

--- a/tests/concurrency-tests.rs
+++ b/tests/concurrency-tests.rs
@@ -1,0 +1,83 @@
+use std::{
+    process::{Child, Command},
+    time::Duration,
+};
+
+use futures::{stream, StreamExt};
+use http::header::{COOKIE, SET_COOKIE};
+use reqwest::Client;
+
+const PARALLEL_REQUESTS: usize = 20;
+const TOTAL_REQUESTS: usize = 10_000;
+const URL: &str = "http://localhost:3000";
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        self.child.kill().expect("Failed to kill example binary");
+        self.child
+            .wait()
+            .expect("Failed to wait for example binary to exit");
+    }
+}
+
+fn start_example_binary() -> ChildGuard {
+    let child = Command::new("cargo")
+        .arg("run")
+        .arg("--example")
+        .arg("counter-concurrent")
+        .spawn()
+        .expect("Failed to start example binary");
+
+    std::thread::sleep(Duration::from_secs(1)); // Wait for the example binary to initialize.
+
+    ChildGuard { child }
+}
+
+#[tokio::test]
+async fn concurrent_counter() {
+    let _child_guard = start_example_binary();
+
+    let urls = vec![URL; TOTAL_REQUESTS];
+    let client = Client::new();
+
+    let resp = client.get(URL).send().await.unwrap();
+    let session_cookie = resp.headers().get(SET_COOKIE).unwrap();
+
+    let bodies = stream::iter(urls)
+        .map(|url| {
+            let client = client.clone();
+            let session_cookie = session_cookie.clone();
+            tokio::spawn(async move {
+                let resp = client
+                    .get(url)
+                    .header(COOKIE, session_cookie)
+                    .send()
+                    .await?;
+                resp.bytes().await
+            })
+        })
+        .buffer_unordered(PARALLEL_REQUESTS);
+
+    let sum = bodies
+        .fold(0, |mut acc, b| async move {
+            match b {
+                Ok(Ok(b)) => {
+                    acc += std::str::from_utf8(&b[..])
+                        .unwrap()
+                        .parse::<usize>()
+                        .unwrap();
+                    acc
+                }
+                Ok(Err(e)) => panic!("reqwest::Error: {}", e),
+                Err(e) => panic!("tokio::JoinError: {}", e),
+            }
+        })
+        .await;
+
+    // Sum = (n/2) * [2a + (n-1)d].
+    assert_eq!(sum, 50_005_000);
+}

--- a/tests/concurrency-tests.rs
+++ b/tests/concurrency-tests.rs
@@ -32,7 +32,7 @@ fn start_example_binary() -> ChildGuard {
         .spawn()
         .expect("Failed to start example binary");
 
-    std::thread::sleep(Duration::from_secs(1)); // Wait for the example binary to initialize.
+    std::thread::sleep(Duration::from_secs(2)); // Wait for the example binary to initialize.
 
     ChildGuard { child }
 }


### PR DESCRIPTION
Here we implement a basic reference counting strategy to allow removal of loaded sessions.

Tracking loaded sessions in this way is necessary to support concurrent session access. For example, if we load from a store in order to provide a session as a request extension, this will load stale data. This happens when concurrently the same session is being modified. In other words, stale data can overwrite the session before its been persisted to the store.

To prevent this without losing the ability to concurrently operate over a session we manage shared memory via a map. When we load a session we also insert this session into the map of loaded sessions. Future requests will first try to read from the map before falling back to the store.

Problematically this map will grow indefinitely, since the only point we can positively remove a session from the map is when it's explicitly deleted or expired. However, since the purpose of this map is shared memory, we only need the session so long as it's being referenced.

This patch adds a simple wrapper around the session which includes a reference count. With some extra accounting, we are now able to safely remove the session from the map without an obvious data race. This ensures that the loaded session map does not grow unboundedly.

Closes #51.