### PR TITLE
Refactor the diesel pool support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,19 +124,19 @@ jobs:
             features: moka-store,sqlite-store
             docker: false
 
-          - store: diesel_pg_store_tests
+          - store: diesel_pg_store
             features: diesel-postgres-store,diesel-r2d2
             docker: true
 
-          - store: diesel_mysql_store_tests
+          - store: diesel_mysql_store
             features: diesel-mysql-store,diesel-r2d2
             docker: true
 
-          - store: diesel_sqlite_store_tests
+          - store: diesel_sqlite_store
             features: diesel-sqlite-store,diesel-r2d2
             docker: false
 
-          - store: deadpool_diesel_sqlite_store_tests
+          - store: deadpool_diesel_sqlite_store
             features: diesel-sqlite-store,diesel-deadpool
             docker: false
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,19 +124,19 @@ jobs:
             features: moka-store,sqlite-store
             docker: false
 
-          - store: postgres_store
+          - store: diesel_pg_store_tests
             features: diesel-postgres-store,diesel-r2d2
-
             docker: true
-          - store: mysql_store
+
+          - store: diesel_mysql_store_tests
             features: diesel-mysql-store,diesel-r2d2
             docker: true
 
-          - store: diesel_store
+          - store: diesel_sqlite_store_tests
             features: diesel-sqlite-store,diesel-r2d2
             docker: false
 
-          - store: deadpool_diesel_store
+          - store: deadpool_diesel_sqlite_store_tests
             features: diesel-sqlite-store,diesel-deadpool
             docker: false
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,17 +124,21 @@ jobs:
             features: moka-store,sqlite-store
             docker: false
 
-          #- store: postgres_store
-          #  features: diesel-postgres-store
+          - store: postgres_store
+            features: diesel-postgres-store,diesel-r2d2
 
-          #  docker: true
-          #- store: mysql_store
-          #  features: diesel-mysql-store
-          #  docker: true
+            docker: true
+          - store: mysql_store
+            features: diesel-mysql-store,diesel-r2d2
+            docker: true
 
-          #- store: diesel_store
-          #  features: diesel-sqlite-store
-          #  docker: false
+          - store: diesel_store
+            features: diesel-sqlite-store,diesel-r2d2
+            docker: false
+
+          - store: deadpool_diesel_store
+            features: diesel-sqlite-store,diesel-deadpool
+            docker: false
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ diesel-store = ["dep:diesel", "tokio/rt", "rmp-serde"]
 diesel-sqlite-store = ["diesel-store", "diesel/sqlite"]
 diesel-postgres-store = ["diesel-store", "diesel/postgres"]
 diesel-mysql-store = ["diesel-store", "diesel/mysql"]
+diesel-r2d2 = ["diesel/r2d2"]
+diesel-deadpool = ["dep:deadpool-diesel", "dep:deadpool"]
 
 [dependencies]
 async-trait = "0.1.73"
@@ -68,9 +70,10 @@ sqlx = { optional = true, version = "0.7.2", features = [
 tokio = { optional = true, version = "1.32.0", default-features = false }
 moka = { optional = true, version = "0.12.0", features = ["future"] }
 diesel = { optional = true, default-features = false, version = "2.1", features = [
-    "r2d2",
     "time",
 ] }
+deadpool-diesel = { version = "0.5", optional = true }
+deadpool = { version ="0.10", optional = true }
 
 [dev-dependencies]
 axum = "0.6.20"
@@ -142,6 +145,7 @@ required-features = [
     "diesel-store",
     "diesel/sqlite",
     "continuously-delete-expired",
+    "diesel-r2d2",
 ]
 
 
@@ -152,4 +156,15 @@ required-features = [
     "diesel-store",
     "diesel/sqlite",
     "continuously-delete-expired",
+    "diesel-r2d2",
+]
+
+[[example]]
+name = "diesel-deadpool"
+required-features = [
+   "axum-core",
+   "diesel-store",
+   "diesel/sqlite",
+   "continuously-delete-expired",
+   "diesel-deadpool",
 ]

--- a/examples/diesel-deadpool.rs
+++ b/examples/diesel-deadpool.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_expiry(Expiry::InactivityDuration(Duration::seconds(10))),
+                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/diesel-deadpool.rs
+++ b/examples/diesel-deadpool.rs
@@ -1,0 +1,69 @@
+use std::net::SocketAddr;
+
+use axum::{
+    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
+};
+use deadpool_diesel::{Manager, Pool};
+use diesel::prelude::*;
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+use time::Duration;
+use tower::ServiceBuilder;
+use tower_sessions::{
+    diesel_store::DieselStore, session_store::ExpiredDeletion, Expiry, Session, SessionManagerLayer,
+};
+
+const COUNTER_KEY: &str = "counter";
+
+#[derive(Serialize, Deserialize, Default)]
+struct Counter(usize);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manager = Manager::<SqliteConnection>::new(":memory:", deadpool_diesel::Runtime::Tokio1);
+    let pool = Pool::builder(manager).max_size(1).build()?;
+    let session_store = DieselStore::new(pool);
+    session_store.migrate().await?;
+
+    let deletion_task = tokio::task::spawn(
+        session_store
+            .clone()
+            .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
+    );
+
+    let session_service = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(|_: BoxError| async {
+            StatusCode::BAD_REQUEST
+        }))
+        .layer(
+            SessionManagerLayer::new(session_store)
+                .with_secure(false)
+                .with_expiry(Expiry::InactivityDuration(Duration::seconds(10))),
+        );
+
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(session_service);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    deletion_task.await??;
+
+    Ok(())
+}
+
+async fn handler(session: Session) -> impl IntoResponse {
+    let counter: Counter = session
+        .get(COUNTER_KEY)
+        .expect("Could not deserialize.")
+        .unwrap_or_default();
+
+    session
+        .insert(COUNTER_KEY, counter.0 + 1)
+        .expect("Could not serialize.");
+
+    format!("Current count: {}", counter.0)
+}

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -115,10 +115,7 @@ where
                     .map_err(Self::Error::Store)?;
 
                 if let Some(ref session) = session {
-                    self.cache
-                        .save(session)
-                        .await
-                        .map_err(Self::Error::Cache)?;
+                    self.cache.save(session).await.map_err(Self::Error::Cache)?;
                 }
 
                 Ok(session)

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -116,7 +116,7 @@ where
 
                 if let Some(ref session) = session {
                     self.cache
-                        .save(&session)
+                        .save(session)
                         .await
                         .map_err(Self::Error::Cache)?;
                 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -26,14 +26,14 @@ services:
     ports:
       - "3306:3306"
 
-  diesel_pg_store_tests:
+  diesel_pg_store:
     image: postgres
     environment:
       POSTGRES_PASSWORD: "postgres"
     ports:
       - "5432:5432"
 
-  diesel_mysql_store_tests:
+  diesel_mysql_store:
     image: mysql
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=true

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -25,3 +25,18 @@ services:
       - MYSQL_DATABASE=public
     ports:
       - "3306:3306"
+
+  diesel_pg_store_tests:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: "postgres"
+    ports:
+      - "5432:5432"
+
+  diesel_mysql_store_tests:
+    image: mysql
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+      - MYSQL_DATABASE=public
+    ports:
+      - "3306:3306"


### PR DESCRIPTION
This commit refactors the support for connection pools for diesel. Instead of only allowing `r2d2` based pools we now abstract the actual pool away. It also adds support for `deadpool-diesel` based pools as alternative.