### PR TITLE
provide session expiration a la django

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio-time = ["tokio/time"]
 continuously-delete-expired = ["tokio-rt", "tokio-time"]
 memory-store = []
 redis-store = ["fred", "rmp-serde"]
-mongodb-store = ["mongodb", "bson"]
+mongodb-store = ["mongodb", "bson", "rmp-serde"]
 sqlx-store = ["sqlx", "rmp-serde"]
 sqlite-store = ["sqlx/sqlite", "sqlx-store"]
 postgres-store = ["sqlx/postgres", "sqlx-store"]
@@ -36,7 +36,7 @@ futures = { version = "0.3.28", default-features = false, features = [
     "async-await",
 ] }
 parking_lot = { version = "0.12.1", features = ["serde"] }
-serde = { version = "1.0.188", features = ["derive"] }
+serde = { version = "1.0.189", features = ["derive", "rc"] }
 serde_json = "1.0.107"
 thiserror = "1.0.49"
 time = { version = "0.3.29", features = ["serde"] }
@@ -45,8 +45,8 @@ tower-layer = "0.3.2"
 tower-service = "0.3.2"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 
-axum-core = { optional = true, version = "0.3.4" }
 fred = { optional = true, version = "7.0.0" }
+axum-core = { optional = true, version = "0.3.4" }
 rmp-serde = { optional = true, version = "1.1.2" }
 mongodb = { optional = true, version = "2.7.0" }
 bson = { optional = true, version = "2.7.0", features = ["time-0_3", "uuid-1"] }

--- a/examples/counter-concurrent.rs
+++ b/examples/counter-concurrent.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
-use tower_sessions::{MemoryStore, Session, SessionManagerLayer};
+use tower_sessions::{MemoryStore, Session, SessionExpiry, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
 
@@ -24,7 +24,7 @@ async fn main() {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::days(1)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::days(1))),
         );
 
     let app = Router::new()

--- a/examples/counter-extractor.rs
+++ b/examples/counter-extractor.rs
@@ -9,7 +9,7 @@ use http::{request::Parts, StatusCode};
 use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
-use tower_sessions::{MemoryStore, Session, SessionManagerLayer};
+use tower_sessions::{MemoryStore, Session, SessionExpiry, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
 
@@ -49,7 +49,7 @@ async fn main() {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
-use tower_sessions::{MemoryStore, Session, SessionManagerLayer};
+use tower_sessions::{MemoryStore, Session, SessionExpiry, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
 
@@ -24,7 +24,7 @@ async fn main() {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/diesel-store.rs
+++ b/examples/diesel-store.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
 use tower_sessions::{
-    diesel_store::DieselStore, session_store::ExpiredDeletion, Session, SessionManagerLayer,
+    diesel_store::DieselStore, session_store::ExpiredDeletion, Session, SessionExpiry,
+    SessionManagerLayer,
 };
 
 const COUNTER_KEY: &str = "counter";
@@ -42,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/moka-postgres-store.rs
+++ b/examples/moka-postgres-store.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
 use tower_sessions::{
-    sqlx::PgPool, CachingSessionStore, MokaStore, PostgresStore, Session, SessionManagerLayer,
+    sqlx::PgPool, CachingSessionStore, MokaStore, PostgresStore, Session, SessionExpiry,
+    SessionManagerLayer,
 };
 
 const COUNTER_KEY: &str = "counter";
@@ -34,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(
             SessionManagerLayer::new(caching_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/mysql-store.rs
+++ b/examples/mysql-store.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
 use tower_sessions::{
-    session_store::ExpiredDeletion, sqlx::MySqlPool, MySqlStore, Session, SessionManagerLayer,
+    session_store::ExpiredDeletion, sqlx::MySqlPool, MySqlStore, Session, SessionExpiry,
+    SessionManagerLayer,
 };
 
 const COUNTER_KEY: &str = "counter";
@@ -36,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/postgres-store.rs
+++ b/examples/postgres-store.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
 use tower_sessions::{
-    session_store::ExpiredDeletion, sqlx::PgPool, PostgresStore, Session, SessionManagerLayer,
+    session_store::ExpiredDeletion, sqlx::PgPool, PostgresStore, Session, SessionExpiry,
+    SessionManagerLayer,
 };
 
 const COUNTER_KEY: &str = "counter";
@@ -36,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/redis-store.rs
+++ b/examples/redis-store.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
-use tower_sessions::{fred::prelude::*, RedisStore, Session, SessionManagerLayer};
+use tower_sessions::{fred::prelude::*, RedisStore, Session, SessionExpiry, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
 
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/sqlite-store.rs
+++ b/examples/sqlite-store.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use time::Duration;
 use tower::ServiceBuilder;
 use tower_sessions::{
-    session_store::ExpiredDeletion, sqlx::SqlitePool, Session, SessionManagerLayer, SqliteStore,
+    session_store::ExpiredDeletion, sqlx::SqlitePool, Session, SessionExpiry, SessionManagerLayer,
+    SqliteStore,
 };
 
 const COUNTER_KEY: &str = "counter";
@@ -35,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/examples/strongly-typed.rs
+++ b/examples/strongly-typed.rs
@@ -9,7 +9,7 @@ use http::{request::Parts, StatusCode};
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 use tower::ServiceBuilder;
-use tower_sessions::{MemoryStore, Session, SessionManagerLayer};
+use tower_sessions::{MemoryStore, Session, SessionExpiry, SessionManagerLayer};
 use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -117,7 +117,7 @@ async fn main() {
         .layer(
             SessionManagerLayer::new(session_store)
                 .with_secure(false)
-                .with_max_age(Duration::seconds(10)),
+                .with_expiry(SessionExpiry::InactivityDuration(Duration::seconds(10))),
         );
 
     let app = Router::new()

--- a/src/moka_store.rs
+++ b/src/moka_store.rs
@@ -3,15 +3,12 @@ use std::convert::Infallible;
 use async_trait::async_trait;
 use moka::future::Cache;
 
-use crate::{
-    session::{SessionId, SessionRecord},
-    Session, SessionStore,
-};
+use crate::{session::SessionId, Session, SessionStore};
 
 /// A session store that uses Moka, a fast and concurrent caching library.
 #[derive(Debug, Clone)]
 pub struct MokaStore {
-    cache: Cache<SessionId, SessionRecord>,
+    cache: Cache<SessionId, Session>,
 }
 
 impl MokaStore {
@@ -41,10 +38,8 @@ impl MokaStore {
 impl SessionStore for MokaStore {
     type Error = Infallible;
 
-    async fn save(&self, session_record: &SessionRecord) -> Result<(), Self::Error> {
-        self.cache
-            .insert(session_record.id(), session_record.clone())
-            .await;
+    async fn save(&self, session: &Session) -> Result<(), Self::Error> {
+        self.cache.insert(*session.id(), session.clone()).await;
         Ok(())
     }
 

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -121,10 +121,11 @@ mod mysql_store_tests {
 #[cfg(all(test, feature = "axum-core", feature = "diesel-store"))]
 mod diesel_sqlite_store_tests {
     use axum::Router;
-    use diesel::prelude::*;
-    use diesel::r2d2::{ConnectionManager, Pool};
-    use tower_sessions::diesel_store::DieselStore;
-    use tower_sessions::SessionManagerLayer;
+    use diesel::{
+        prelude::*,
+        r2d2::{ConnectionManager, Pool},
+    };
+    use tower_sessions::{diesel_store::DieselStore, SessionManagerLayer};
 
     use crate::common::build_app;
 
@@ -151,10 +152,11 @@ mod diesel_sqlite_store_tests {
 ))]
 mod diesel_pg_store_tests {
     use axum::Router;
-    use diesel::prelude::*;
-    use diesel::r2d2::{ConnectionManager, Pool};
-    use tower_sessions::diesel_store::DieselStore;
-    use tower_sessions::SessionManagerLayer;
+    use diesel::{
+        prelude::*,
+        r2d2::{ConnectionManager, Pool},
+    };
+    use tower_sessions::{diesel_store::DieselStore, SessionManagerLayer};
 
     use crate::common::build_app;
 
@@ -182,10 +184,11 @@ mod diesel_pg_store_tests {
 ))]
 mod diesel_mysql_store_tests {
     use axum::Router;
-    use diesel::prelude::*;
-    use diesel::r2d2::{ConnectionManager, Pool};
-    use tower_sessions::diesel_store::DieselStore;
-    use tower_sessions::SessionManagerLayer;
+    use diesel::{
+        prelude::*,
+        r2d2::{ConnectionManager, Pool},
+    };
+    use tower_sessions::{diesel_store::DieselStore, SessionManagerLayer};
 
     use crate::common::build_app;
 


### PR DESCRIPTION
Here we rework how session expiration works, implementing a new type, `SessionExpiry` (later to be renamed `Expiry`). This enum defines three possible types of expiry,

1. Activity durations, i.e. durations for which the session will be renewed until inactivity for that duration has elapsed,
2. Absolute expirations, i.e. timestamps at which the session will expire regardless of activity,
3. And browser sessions, which are sessions that are valid for so long as the client remains open or the default threshold (two weeks) is reached.

Several breaking changes are required to make this change and importantly, the session itself is now serialized to the session store. This also means we no longer need `SessionRecord` and it has been removed entirely.

Please note that fields and methods related to "expiration" have been renamed or removed and with this change all use cases for the expiration are provided for by the expiry type.

Closes #57.