### PR TITLE
ensure session lifecycle states are reset

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -185,8 +185,10 @@ where
 
                         session_store.delete(&deleted_id).await?;
                         cookies.remove(session_config.build_cookie(&session));
+                        session.reset_deleted();
 
                         if session.is_modified() {
+                            session.reset_modified();
                             session.id = Id::default();
                             session_store.save(&session).await?;
                             cookies.add(session_config.build_cookie(&session));
@@ -210,6 +212,8 @@ where
                     let loaded = entry.get_mut();
 
                     if session.is_modified() {
+                        session.reset_modified();
+
                         session_store.save(&session).await?;
                         cookies.add(session_config.build_cookie(&session));
                     }
@@ -224,6 +228,8 @@ where
 
                 Entry::Vacant(entry) => {
                     if session.is_modified() {
+                        session.reset_modified();
+
                         entry.insert(LoadedSession {
                             session: session.clone(),
                             refs: 0,

--- a/src/session.rs
+++ b/src/session.rs
@@ -310,6 +310,16 @@ impl Session {
         inner.deleted = Some(Deletion::Deleted);
     }
 
+    pub(crate) fn reset_deleted(&self) {
+        let mut inner = self.inner.lock();
+        inner.deleted = None;
+    }
+
+    pub(crate) fn reset_modified(&self) {
+        let mut inner = self.inner.lock();
+        inner.modified_at = None;
+    }
+
     /// Sets `deleted` on the session to `Deletion::Cycled(self.id))`.
     ///
     /// Setting this flag indicates the session ID should be cycled while


### PR DESCRIPTION
Now that the session is serialized to the storage backend, we also need to ensure that we reset the lifecycle markers before saving back to the store.