### PR TITLE
ensure non-negative max-age

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -462,13 +462,21 @@ impl Session {
     /// # Examples
     ///
     /// ```rust
-    /// use time::Duration;
+    /// use time::{Duration, OffsetDateTime};
     /// use tower_sessions::Session;
+    /// use tower_sessions::Expiry;
     ///
     /// let session = Session::default();
     /// assert!(session.expiry_age() > Duration::days(11));   
+    ///
+    /// let yesterday = OffsetDateTime::now_utc().saturating_sub(Duration::days(1));
+    /// session.set_expiry(Some(Expiry::AtDateTime(yesterday)));
+    /// assert_eq!(session.expiry_age(), Duration::ZERO);
     pub fn expiry_age(&self) -> Duration {
-        self.expiry_date() - OffsetDateTime::now_utc()
+        std::cmp::max(
+            self.expiry_date() - OffsetDateTime::now_utc(),
+            Duration::ZERO,
+        )
     }
 
     /// Returns `true` if the session has been modified and `false` otherwise.


### PR DESCRIPTION
This addresses a bug revealed in #77, where `Max-Age` may be set to some negative value.

Here we address this by instead setting `Max-Age` to zero in cases where it would otherwise be a negative value. Doing so helps ensure the removal of expired session cookies.