### PR TITLE
use a default session name of "id"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+**Breaking Changes**
+
+- Use a default session name of "id" to avoid fingerprinting, as per https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-name-fingerprinting.
+
 # 0.4.3
 
 ## **Important Security Fix**

--- a/src/service.rs
+++ b/src/service.rs
@@ -54,7 +54,7 @@ impl SessionConfig {
 impl Default for SessionConfig {
     fn default() -> Self {
         Self {
-            name: String::from("tower.sid"),
+            name: String::from("id"), /* See: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-id-name-fingerprinting */
             http_only: true,
             same_site: SameSite::Strict,
             expiry: None, // TODO: Is `Max-Age: "Session"` the right default?

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -112,7 +112,7 @@ macro_rules! route_tests {
 
         #[tokio::test]
         async fn bogus_session_cookie() {
-            let session_cookie = Cookie::new("tower.sid", "00000000-0000-0000-0000-000000000000");
+            let session_cookie = Cookie::new("id", "00000000-0000-0000-0000-000000000000");
             let req = Request::builder()
                 .uri("/insert")
                 .header(header::COOKIE, session_cookie.encoded().to_string())
@@ -134,7 +134,7 @@ macro_rules! route_tests {
 
         #[tokio::test]
         async fn malformed_session_cookie() {
-            let session_cookie = Cookie::new("tower.sid", "malformed");
+            let session_cookie = Cookie::new("id", "malformed");
             let req = Request::builder()
                 .uri("/")
                 .header(header::COOKIE, session_cookie.encoded().to_string())
@@ -162,7 +162,7 @@ macro_rules! route_tests {
                 .unwrap();
             let session_cookie = get_session_cookie(res.headers()).unwrap();
 
-            assert_eq!(session_cookie.name(), "tower.sid");
+            assert_eq!(session_cookie.name(), "id");
             assert_eq!(session_cookie.http_only(), Some(true));
             assert_eq!(session_cookie.same_site(), Some(SameSite::Strict));
             assert!(session_cookie
@@ -181,7 +181,7 @@ macro_rules! route_tests {
             let res = $create_app(None).await.oneshot(req).await.unwrap();
             let session_cookie = get_session_cookie(res.headers()).unwrap();
 
-            assert_eq!(session_cookie.name(), "tower.sid");
+            assert_eq!(session_cookie.name(), "id");
             assert_eq!(session_cookie.http_only(), Some(true));
             assert_eq!(session_cookie.same_site(), Some(SameSite::Strict));
             assert!(session_cookie


### PR DESCRIPTION
This helps avoid fingerprinting.

Closes #73.