### PR TITLE
Add `RedisPoolStore` implementation 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,10 @@ jobs:
             features: redis-store
             docker: true
 
+          - store: redis_store
+            features: redis-pool-store
+            docker: true
+
           - store: mongodb_store
             features: mongodb-store
             docker: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "moka-store",
     "mongodb-store",
     "redis-store",
+    "redis-pool-store",
     "sqlx-store",
     "tower-sessions-core",
 ]
@@ -51,6 +52,7 @@ deletion-task = ["tower-sessions-core/deletion-task"]
 memory-store = ["tower-sessions-memory-store"]
 moka-store = ["tower-sessions-moka-store"]
 redis-store = ["tower-sessions-redis-store"]
+redis-pool-store = ["tower-sessions-redis-pool-store"]
 mongodb-store = ["tower-sessions-mongodb-store"]
 sqlx-store = []
 sqlite-store = ["sqlx-store", "tower-sessions-sqlx-store/sqlite"]
@@ -64,6 +66,7 @@ tower-sessions-core = { version = "=0.6.0", path = "tower-sessions-core", defaul
 tower-sessions-memory-store = { version = "=0.6.0", path = "memory-store" }
 tower-sessions-moka-store = { version = "=0.6.0", path = "moka-store" }
 tower-sessions-redis-store = { version = "=0.6.0", path = "redis-store" }
+tower-sessions-redis-pool-store = { version = "=0.6.0", path = "redis-pool-store" }
 tower-sessions-mongodb-store = { version = "=0.6.0", path = "mongodb-store" }
 tower-sessions-sqlx-store = { version = "=0.6.0", path = "sqlx-store" }
 
@@ -79,6 +82,7 @@ tower-sessions-core = { workspace = true, features = ["axum-core"] }
 tower-sessions-memory-store = { workspace = true, optional = true }
 tower-sessions-moka-store = { workspace = true, optional = true }
 tower-sessions-redis-store = { workspace = true, optional = true }
+tower-sessions-redis-pool-store = { workspace = true, optional = true }
 tower-sessions-mongodb-store = { workspace = true, optional = true }
 tower-sessions-sqlx-store = { workspace = true, optional = true }
 
@@ -111,6 +115,10 @@ required-features = ["axum-core", "memory-store"]
 [[example]]
 name = "redis-store"
 required-features = ["axum-core", "redis-store"]
+
+[[example]]
+name = "redis-pool-store"
+required-features = ["axum-core", "redis-pool-store"]
 
 [[example]]
 name = "mongodb-store"

--- a/examples/redis-pool-store.rs
+++ b/examples/redis-pool-store.rs
@@ -36,9 +36,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
 }

--- a/examples/redis-pool-store.rs
+++ b/examples/redis-pool-store.rs
@@ -1,0 +1,54 @@
+use std::net::SocketAddr;
+
+use axum::{
+    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
+};
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+use time::Duration;
+use tower::ServiceBuilder;
+use tower_sessions::{redis, Expiry, RedisPoolStore, Session, SessionManagerLayer};
+
+const COUNTER_KEY: &str = "counter";
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+struct Counter(usize);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let redis_url = "redis://127.0.0.1:6379";
+    let client =
+        redis::Client::open(redis_url).expect("Error while trying to open the redis connection");
+
+    let session_store = RedisPoolStore::new(client.into());
+    let session_service = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(|_: BoxError| async {
+            StatusCode::BAD_REQUEST
+        }))
+        .layer(
+            SessionManagerLayer::new(session_store)
+                .with_secure(false)
+                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
+        );
+
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(session_service);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    Ok(())
+}
+
+async fn handler(session: Session) -> impl IntoResponse {
+    let counter = session.get(COUNTER_KEY);
+    let counter: Counter = counter.expect("Could not deserialize.").unwrap_or_default();
+    session
+        .insert(COUNTER_KEY, counter.0 + 1)
+        .expect("Could not serialize.");
+
+    format!("Current count: {}", counter.0)
+}

--- a/redis-pool-store/Cargo.toml
+++ b/redis-pool-store/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 redis_pool = "0.2.1"
-redis = "0.23.4"
+redis = { version = "0.23.3", default_features = false, features = ["aio", "tokio-comp"] }
 rmp-serde = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }

--- a/redis-pool-store/Cargo.toml
+++ b/redis-pool-store/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tower-sessions-redis-pool-store"
+description = "Redis session store with pool support. Not for direct use; see the `tower-sessions` crate for details."
+documentation.workspace = true
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+redis_pool = "0.2.1"
+redis = "0.23.4"
+rmp-serde = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+tower-sessions-core = { workspace = true }
+
+[dev-dependencies]
+tower-sessions = { workspace = true }
+tokio-test = "0.4.3"

--- a/redis-pool-store/src/lib.rs
+++ b/redis-pool-store/src/lib.rs
@@ -1,0 +1,96 @@
+use async_trait::async_trait;
+pub use redis;
+pub use redis_pool;
+use redis_pool::SingleRedisPool;
+use time::OffsetDateTime;
+use tower_sessions_core::{session::Id, Session, SessionStore};
+
+/// An error type for `RedisPoolStore`.
+#[derive(thiserror::Error, Debug)]
+pub enum RedisStoreError {
+    /// A variant to map to `redis_pool::errors::RedisPoolError` errors.
+    #[error("RedisPool error: {0}")]
+    RedisPool(#[from] redis_pool::errors::RedisPoolError),
+
+    /// A variant to map to `redis::RedisError` errors.
+    #[error("Redis error: {0}")]
+    Redis(#[from] redis::RedisError),
+
+    /// A variant to map `rmp_serde` encode errors.
+    #[error("Rust MsgPack encode error: {0}")]
+    RmpSerdeEncode(#[from] rmp_serde::encode::Error),
+
+    /// A variant to map `rmp_serde` decode errors.
+    #[error("Rust MsgPack decode error: {0}")]
+    RmpSerdeDecode(#[from] rmp_serde::decode::Error),
+}
+
+/// A Redis session store.
+#[derive(Clone)]
+pub struct RedisPoolStore {
+    client: SingleRedisPool,
+}
+
+impl RedisPoolStore {
+    /// Create a new Redis store with the provided client.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use redis_pool::RedisPool;
+    /// use redis::Client;
+    /// use tower_sessions::RedisPoolStore;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let redis_url = "redis://127.0.0.1:6379";
+    /// let client = redis::Client::open(redis_url).expect("Error while trying to open the redis connection");
+    ///
+    /// let session_store = RedisPoolStore::new(client.into());
+    /// })
+    /// ```
+    pub fn new(client: SingleRedisPool) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl SessionStore for RedisPoolStore {
+    type Error = RedisStoreError;
+
+    async fn save(&self, session: &Session) -> Result<(), Self::Error> {
+        let expire = OffsetDateTime::unix_timestamp(session.expiry_date());
+        let mut con = self.client.aquire().await?;
+        redis::pipe()
+            .atomic() //makes this a transation.
+            .set(session.id().to_string(), rmp_serde::to_vec(&session)?)
+            .ignore()
+            .expire_at(session.id().to_string(), expire as usize)
+            .ignore()
+            .query_async(&mut con)
+            .await?;
+        Ok(())
+    }
+
+    async fn load(&self, session_id: &Id) -> Result<Option<Session>, Self::Error> {
+        let mut con = self.client.aquire().await?;
+        let data: Option<Vec<u8>> = redis::cmd("GET")
+            .arg(session_id.to_string())
+            .query_async(&mut con)
+            .await?;
+        if let Some(data) = data {
+            Ok(Some(rmp_serde::from_slice(&data)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn delete(&self, session_id: &Id) -> Result<(), Self::Error> {
+        let mut con = self.client.aquire().await?;
+        redis::pipe()
+            .cmd("DEL")
+            .arg(session_id.to_string().as_str())
+            .query_async(&mut con)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,6 +461,14 @@ pub use tower_sessions_mongodb_store::mongodb;
 #[cfg_attr(docsrs, doc(cfg(feature = "mongodb-store")))]
 #[doc(inline)]
 pub use tower_sessions_mongodb_store::MongoDBStore;
+#[cfg(feature = "redis-pool-store")]
+pub use tower_sessions_redis_pool_store::redis;
+#[cfg(feature = "redis-pool-store")]
+pub use tower_sessions_redis_pool_store::redis_pool;
+#[cfg(feature = "redis-pool-store")]
+#[cfg_attr(docsrs, doc(cfg(feature = "redis-pool-store")))]
+#[doc(inline)]
+pub use tower_sessions_redis_pool_store::RedisPoolStore;
 #[cfg(feature = "redis-store")]
 pub use tower_sessions_redis_store::fred;
 #[cfg(feature = "redis-store")]

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -58,6 +58,28 @@ mod redis_store_tests {
     route_tests!(app);
 }
 
+#[cfg(all(test, feature = "axum-core", feature = "redis-pool-store"))]
+mod redis_store_pool_tests {
+    use axum::Router;
+    use tower_sessions::{redis, RedisPoolStore, SessionManagerLayer};
+
+    use crate::common::build_app;
+
+    async fn app(max_age: Option<Duration>) -> Router {
+        let database_url = std::option_env!("REDIS_URL").unwrap();
+
+        let client = redis::Client::open(database_url)
+            .expect("Error while trying to open the redis connection");
+
+        let session_store = RedisPoolStore::new(client.into());
+        let session_manager = SessionManagerLayer::new(session_store).with_secure(true);
+
+        build_app(session_manager, max_age)
+    }
+
+    route_tests!(app);
+}
+
 #[cfg(all(test, feature = "axum-core", feature = "sqlite-store"))]
 mod sqlite_store_tests {
     use axum::Router;


### PR DESCRIPTION
This PR implements a new store `RedisPoolStore` using `redis_pool` (a wrapper over `redis`) following #96.

I thought of merging `RedisStore` and `RedisPoolStore` like you did with `sqlx-store`,
but coming from different crates I ultimately decided to separe them.

Let me know if I need to fix anything.

Cheers!