### PR TITLE
Bump axum-core to 0.4.0, http to 0.1, tower-cookies to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,21 +84,22 @@ tower-sessions-sqlx-store = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-trait = "0.1.74"
-axum = "0.6.20"
-axum-core = "0.3.4"
+axum = "0.7.1"
+axum-core = "0.4.0"
 futures = { version = "0.3.28", default-features = false, features = [
     "async-await",
 ] }
-http = "0.2.10"
-hyper = "0.14.27"
+http = "1.0"
+hyper = "1.0"
 reqwest = "0.11.22"
 serde = "1.0.192"
 time = "0.3.30"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 tower = "0.4.13"
-tower-cookies = "0.9.0"
+tower-cookies = "0.10.0"
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
+http-body-util = "0.1"
 
 [[example]]
 name = "counter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ futures = { version = "0.3.28", default-features = false, features = [
 ] }
 http = "1.0"
 hyper = "1.0"
-reqwest = "0.11.22"
+reqwest = { version = "0.11.22", default-features = false, features = ["rustls"] }
 serde = "1.0.192"
 time = "0.3.30"
 tokio = { version = "1.32.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ async fn main() {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
 }

--- a/examples/counter-extractor.rs
+++ b/examples/counter-extractor.rs
@@ -57,8 +57,8 @@ async fn main() {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
 }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -32,8 +32,8 @@ async fn main() {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
 }

--- a/examples/moka-postgres-store.rs
+++ b/examples/moka-postgres-store.rs
@@ -43,9 +43,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
 }

--- a/examples/mongodb-store.rs
+++ b/examples/mongodb-store.rs
@@ -34,9 +34,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
 }

--- a/examples/mysql-store.rs
+++ b/examples/mysql-store.rs
@@ -45,9 +45,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     deletion_task.await??;
 

--- a/examples/postgres-store.rs
+++ b/examples/postgres-store.rs
@@ -45,9 +45,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     deletion_task.await??;
 

--- a/examples/redis-store.rs
+++ b/examples/redis-store.rs
@@ -37,9 +37,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     redis_conn.await??;
 

--- a/examples/sqlite-store.rs
+++ b/examples/sqlite-store.rs
@@ -44,9 +44,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     deletion_task.await??;
 

--- a/examples/strongly-typed.rs
+++ b/examples/strongly-typed.rs
@@ -125,8 +125,8 @@ async fn main() {
         .layer(session_service);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@
 //!         .layer(session_service);
 //!
 //!     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-//!     axum::Server::bind(&addr)
-//!         .serve(app.into_make_service())
+//!     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+//!     axum::serve(listener, app.into_make_service())
 //!         .await
 //!         .unwrap();
 //! }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,7 @@
 use axum::{error_handling::HandleErrorLayer, routing::get, Router};
-use axum_core::{body::BoxBody, BoxError};
+use axum_core::{body::Body, BoxError};
 use http::{header, HeaderMap, StatusCode};
+use http_body_util::BodyExt;
 use time::Duration;
 use tower::ServiceBuilder;
 use tower_cookies::{cookie, Cookie};
@@ -68,8 +69,8 @@ pub fn build_app<Store: SessionStore>(
     routes().layer(session_service)
 }
 
-pub async fn body_string(body: BoxBody) -> String {
-    let bytes = hyper::body::to_bytes(body).await.unwrap();
+pub async fn body_string(body: Body) -> String {
+    let bytes = body.collect().await.unwrap().to_bytes();
     String::from_utf8_lossy(&bytes).into()
 }
 

--- a/tower-sessions-core/Cargo.toml
+++ b/tower-sessions-core/Cargo.toml
@@ -15,18 +15,18 @@ deletion-task = ["tokio/time"]
 
 [dependencies]
 async-trait = "0.1.73"
-axum-core = { version = "0.3.4", optional = true }
+axum-core = { version = "0.4.0", optional = true }
 futures = { version = "0.3.28", default-features = false, features = [
     "async-await",
 ] }
-http = "0.2.9"
+http = "1.0"
 parking_lot = { version = "0.12.1", features = ["serde"] }
 serde = { version = "1.0.189", features = ["derive", "rc"] }
 serde_json = "1.0.107"
 thiserror = "1.0.49"
 time = { version = "0.3.29", features = ["serde"] }
 tokio = { version = "1.32.0", optional = true, default-features = false }
-tower-cookies = "0.9.0"
+tower-cookies = "0.10.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
 tracing = { version = "0.1.40", features = ["log"] }

--- a/tower-sessions-core/src/service.rs
+++ b/tower-sessions-core/src/service.rs
@@ -29,7 +29,7 @@ struct SessionConfig {
 
 impl SessionConfig {
     fn build_cookie<'c>(&self, session: &Session) -> Cookie<'c> {
-        let mut cookie_builder = Cookie::build(self.name.clone(), session.id().to_string())
+        let mut cookie_builder = Cookie::build((self.name.clone(), session.id().to_string()))
             .http_only(self.http_only)
             .same_site(self.same_site)
             .secure(self.secure)
@@ -41,7 +41,7 @@ impl SessionConfig {
             cookie_builder = cookie_builder.domain(domain.clone());
         }
 
-        cookie_builder.finish()
+        cookie_builder.build()
     }
 
     fn new_session(&self) -> Session {


### PR DESCRIPTION
Closes https://github.com/maxcountryman/tower-sessions/pull/104.

---

I'd be happy to drop b5de6e55a4eb24e19540c4464ae7dae818351b90 -- it just made it easier for me to run the various tests and build the examples without needing to setup `pkg-config` and `openssl`.