### PR TITLE
Add getters for pool and table name for sqlite store

### DIFF
--- a/sqlx-store/src/sqlite_store.rs
+++ b/sqlx-store/src/sqlite_store.rs
@@ -63,6 +63,16 @@ impl SqliteStore {
         sqlx::query(&query).execute(&self.pool).await?;
         Ok(())
     }
+
+    /// Get the store's pool
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    /// Get the store's table name
+    pub fn table_name(&self) -> &str {
+        &self.table_name
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
I'm using tower-sessions' sqlite capabilities, but I'm using SeaORM to interface with my database. Because of this, when implementing authentication, it's most efficient if I can use the store's pool (which refers to the same db as my users are stored in) to retrieve the users, and improves ergonomics because I don't have to pass around another connection. This facilitates that use case.
