### PR TITLE
Allow constructing a `RedisStore` from a `RedisPool`

### DIFF
--- a/examples/redis-store.rs
+++ b/examples/redis-store.rs
@@ -16,12 +16,12 @@ struct Counter(usize);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = RedisClient::default();
+    let pool = RedisPool::new(RedisConfig::default(), None, None, None, 6)?;
 
-    let redis_conn = client.connect();
-    client.wait_for_connect().await?;
+    let redis_conn = pool.connect();
+    pool.wait_for_connect().await?;
 
-    let session_store = RedisStore::new(client);
+    let session_store = RedisStore::new(pool);
     let session_service = ServiceBuilder::new()
         .layer(HandleErrorLayer::new(|_: BoxError| async {
             StatusCode::BAD_REQUEST

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -44,12 +44,12 @@ mod redis_store_tests {
         let database_url = std::option_env!("REDIS_URL").unwrap();
 
         let config = RedisConfig::from_url(database_url).unwrap();
-        let client = RedisClient::new(config, None, None, None);
+        let pool = RedisPool::new(config, None, None, None, 6).unwrap();
 
-        client.connect();
-        client.wait_for_connect().await.unwrap();
+        pool.connect();
+        pool.wait_for_connect().await.unwrap();
 
-        let session_store = RedisStore::new(client);
+        let session_store = RedisStore::new(pool);
         let session_manager = SessionManagerLayer::new(session_store).with_secure(true);
 
         build_app(session_manager, max_age)


### PR DESCRIPTION
Makes `RedisStore` generic over any type that implements fred's `KeysInterface` so either a `RedisClient` or `RedisPool` can be used.

Since `RedisPool` is generally preferred for most applications, I switched all examples and documentation to use `RedisPool`. But, existing code that used `RedisClient` will not fail to compile.

I also modified the integration test that tests `RedisStore` to use a `RedisPool`.

Fixes issue #92