### PR TITLE
make service infallible

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,9 @@ tower-sessions = "0.8.2"
 ```rust
 use std::net::SocketAddr;
 
-use axum::{
-    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-};
-use http::StatusCode;
+use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{Expiry, MemoryStore, Session, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
@@ -87,19 +83,11 @@ struct Counter(usize);
 #[tokio::main]
 async fn main() {
     let session_store = MemoryStore::default();
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();

--- a/examples/counter-extractor.rs
+++ b/examples/counter-extractor.rs
@@ -1,14 +1,10 @@
 use std::net::SocketAddr;
 
 use async_trait::async_trait;
-use axum::{
-    error_handling::HandleErrorLayer, extract::FromRequestParts, response::IntoResponse,
-    routing::get, BoxError, Router,
-};
-use http::{request::Parts, StatusCode};
+use axum::{extract::FromRequestParts, response::IntoResponse, routing::get, Router};
+use http::request::Parts;
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{Expiry, MemoryStore, Session, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
@@ -34,19 +30,11 @@ where
 #[tokio::main]
 async fn main() {
     let session_store = MemoryStore::default();
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,12 +1,8 @@
 use std::net::SocketAddr;
 
-use axum::{
-    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-};
-use http::StatusCode;
+use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{Expiry, MemoryStore, Session, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
@@ -17,19 +13,11 @@ struct Counter(usize);
 #[tokio::main]
 async fn main() {
     let session_store = MemoryStore::default();
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();

--- a/examples/mongodb-store.rs
+++ b/examples/mongodb-store.rs
@@ -1,12 +1,8 @@
 use std::net::SocketAddr;
 
-use axum::{
-    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-};
-use http::StatusCode;
+use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{mongodb::Client, Expiry, MongoDBStore, Session, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
@@ -19,19 +15,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database_url = std::option_env!("DATABASE_URL").expect("Missing DATABASE_URL.");
     let client = Client::with_uri_str(database_url).await?;
     let session_store = MongoDBStore::new(client, "tower-sessions".to_string());
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/examples/mysql-store.rs
+++ b/examples/mysql-store.rs
@@ -1,12 +1,8 @@
 use std::net::SocketAddr;
 
-use axum::{
-    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-};
-use http::StatusCode;
+use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{
     session_store::ExpiredDeletion, sqlx::MySqlPool, Expiry, MySqlStore, Session,
     SessionManagerLayer,
@@ -30,19 +26,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
     );
 
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/examples/postgres-store.rs
+++ b/examples/postgres-store.rs
@@ -1,12 +1,8 @@
 use std::net::SocketAddr;
 
-use axum::{
-    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-};
-use http::StatusCode;
+use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{
     session_store::ExpiredDeletion, sqlx::PgPool, Expiry, PostgresStore, Session,
     SessionManagerLayer,
@@ -30,19 +26,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
     );
 
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/examples/redis-store.rs
+++ b/examples/redis-store.rs
@@ -1,12 +1,8 @@
 use std::net::SocketAddr;
 
-use axum::{
-    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-};
-use http::StatusCode;
+use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{fred::prelude::*, Expiry, RedisStore, Session, SessionManagerLayer};
 
 const COUNTER_KEY: &str = "counter";
@@ -22,19 +18,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pool.wait_for_connect().await?;
 
     let session_store = RedisStore::new(pool);
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/examples/sqlite-store.rs
+++ b/examples/sqlite-store.rs
@@ -1,12 +1,8 @@
 use std::net::SocketAddr;
 
-use axum::{
-    error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-};
-use http::StatusCode;
+use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_sessions::{
     session_store::ExpiredDeletion, sqlx::SqlitePool, Expiry, Session, SessionManagerLayer,
     SqliteStore,
@@ -29,19 +25,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
     );
 
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(
-            SessionManagerLayer::new(session_store)
-                .with_secure(false)
-                .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-        );
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,13 +39,9 @@
 //! ```rust,no_run
 //! use std::net::SocketAddr;
 //!
-//! use axum::{
-//!     error_handling::HandleErrorLayer, response::IntoResponse, routing::get, BoxError, Router,
-//! };
-//! use http::StatusCode;
+//! use axum::{response::IntoResponse, routing::get, Router};
 //! use serde::{Deserialize, Serialize};
 //! use time::Duration;
-//! use tower::ServiceBuilder;
 //! use tower_sessions::{Expiry, MemoryStore, Session, SessionManagerLayer};
 //!
 //! const COUNTER_KEY: &str = "counter";
@@ -56,19 +52,11 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let session_store = MemoryStore::default();
-//!     let session_service = ServiceBuilder::new()
-//!         .layer(HandleErrorLayer::new(|_: BoxError| async {
-//!             StatusCode::BAD_REQUEST
-//!         }))
-//!         .layer(
-//!             SessionManagerLayer::new(session_store)
-//!                 .with_secure(false)
-//!                 .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-//!         );
+//!     let session_layer = SessionManagerLayer::new(session_store)
+//!         .with_secure(false)
+//!         .with_expiry(Expiry::OnInactivity(Duration::seconds(10)));
 //!
-//!     let app = Router::new()
-//!         .route("/", get(handler))
-//!         .layer(session_service);
+//!     let app = Router::new().route("/", get(handler)).layer(session_layer);
 //!
 //!     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 //!     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,8 @@
-use axum::{error_handling::HandleErrorLayer, routing::get, Router};
-use axum_core::{body::Body, BoxError};
-use http::{header, HeaderMap, StatusCode};
+use axum::{routing::get, Router};
+use axum_core::body::Body;
+use http::{header, HeaderMap};
 use http_body_util::BodyExt;
 use time::Duration;
-use tower::ServiceBuilder;
 use tower_cookies::{cookie, Cookie};
 use tower_sessions::{Expiry, Session, SessionManagerLayer, SessionStore};
 
@@ -62,13 +61,7 @@ pub fn build_app<Store: SessionStore + Clone>(
         session_manager = session_manager.with_expiry(Expiry::OnInactivity(max_age));
     }
 
-    let session_service = ServiceBuilder::new()
-        .layer(HandleErrorLayer::new(|_: BoxError| async {
-            StatusCode::BAD_REQUEST
-        }))
-        .layer(session_manager);
-
-    routes().layer(session_service)
+    routes().layer(session_manager)
 }
 
 pub async fn body_string(body: Body) -> String {

--- a/tower-sessions-core/src/session.rs
+++ b/tower-sessions-core/src/session.rs
@@ -34,14 +34,6 @@ pub enum Error {
 
     #[error(transparent)]
     Store(#[from] session_store::Error),
-
-    /// Missing session ID.
-    #[error("Missing session ID")]
-    MissingId,
-
-    /// Missing cookies.
-    #[error("Missing cookies; is tower-cookies set up?")]
-    MissingCookies,
 }
 
 /// A session which allows HTTP applications to associate key-value pairs with


### PR DESCRIPTION
This reworks the tower service such that we always return a response. In other words, the service becomes infallible. What this means is we no longer need to build an intermediary service that captures boxed errors when using this crate with axum.

One side effect of this is that we lose the ability to handle specific errors, such as the session save failing, via downcasting. Instead, the middleware will return a 500 response. To address this, we could extend this implementation to allow for an on error callback, which could take an error and return a response.

This is a breaking change which also removes two extraneous variants from the session error type:

- `MissingId`
- `MissingCookies`