### PR TITLE
ensure expires session

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -37,7 +37,9 @@ impl SessionConfig {
             .secure(self.secure)
             .path(self.path.clone());
 
-        cookie_builder = cookie_builder.max_age(expiry_age);
+        if !matches!(self.expiry, Some(Expiry::OnSessionEnd) | None) {
+            cookie_builder = cookie_builder.max_age(expiry_age);
+        }
 
         if let Some(domain) = &self.domain {
             cookie_builder = cookie_builder.domain(domain.clone());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -179,9 +179,7 @@ macro_rules! route_tests {
             assert_eq!(session_cookie.name(), "id");
             assert_eq!(session_cookie.http_only(), Some(true));
             assert_eq!(session_cookie.same_site(), Some(SameSite::Strict));
-            assert!(session_cookie
-                .max_age()
-                .is_some_and(|d| d <= Duration::weeks(2)));
+            assert!(session_cookie.max_age().is_none());
             assert_eq!(session_cookie.secure(), Some(true));
             assert_eq!(session_cookie.path(), Some("/"));
         }


### PR DESCRIPTION
Here we manually check the configured session expiry to ensure that we account for `Expires: Session`.

This follows the Django implementation.

See: https://github.com/django/django/blob/9c6d7b4a678b7bbc6a1a14420f686162ba9016f5/django/contrib/sessions/middleware.py#L48-L49