### PR TITLE
manually set path and domain on removal

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -147,8 +147,18 @@ where
                 tracing::trace!(modified = modified, empty = empty, "session response state");
 
                 match session_cookie {
-                    Some(cookie) if empty => {
+                    Some(mut cookie) if empty => {
                         tracing::debug!("removing session cookie");
+
+                        // Path and domain must be manually set to ensure a proper removal cookie is
+                        // constructed.
+                        //
+                        // See: https://docs.rs/cookie/latest/cookie/struct.CookieJar.html#method.remove
+                        cookie.set_path(session_config.path);
+                        if let Some(domain) = session_config.domain {
+                            cookie.set_domain(domain);
+                        }
+
                         cookies.remove(cookie)
                     }
 

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -8,10 +8,10 @@ mod memory_store_tests {
 
     use crate::common::build_app;
 
-    async fn app(max_age: Option<Duration>) -> Router {
+    async fn app(max_age: Option<Duration>, domain: Option<String>) -> Router {
         let session_store = MemoryStore::default();
         let session_manager = SessionManagerLayer::new(session_store).with_secure(true);
-        build_app(session_manager, max_age)
+        build_app(session_manager, max_age, domain)
     }
 
     route_tests!(app);


### PR DESCRIPTION
This ensures that configured paths and domains are provided to the cookie managed by the underlying cookie jar.

Note that this has no bearing on deletion from stores, which handle removal regardless of this change.