### PR TITLE
session cookie signing and encryption

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,6 +56,19 @@ jobs:
         run: |
           cargo test --workspace --all-features --doc
 
+  test-lib:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          rustup toolchain install nightly --profile minimal
+          cargo install cargo-tarpaulin
+      - uses: Swatinem/rust-cache@v2
+      - name: Run lib tests
+        run: |
+          cargo test --workspace --all-features --lib
+
   test-integration:
     needs: check
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ time = { version = "0.3.29", features = ["serde"] }
 
 [dev-dependencies]
 async-trait = "0.1.74"
+anyhow = "1"
 axum = "0.7.1"
 axum-core = "0.4.0"
 futures = { version = "0.3.28", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["axum-core", "memory-store"]
 axum-core = ["tower-sessions-core/axum-core"]
 memory-store = ["tower-sessions-memory-store"]
+signed = ["tower-cookies/signed"]
+private = ["tower-cookies/private"]
 
 [workspace.dependencies]
 tower-sessions = { version = "=0.11.0", path = ".", default-features = false }
@@ -95,3 +97,7 @@ required-features = ["axum-core", "memory-store"]
 [[example]]
 name = "strongly-typed"
 required-features = ["axum-core"]
+
+[[example]]
+name = "signed"
+required-features = ["signed", "memory-store"]

--- a/examples/signed.rs
+++ b/examples/signed.rs
@@ -1,0 +1,36 @@
+use std::net::SocketAddr;
+
+use axum::{response::IntoResponse, routing::get, Router};
+use serde::{Deserialize, Serialize};
+use time::Duration;
+use tower_sessions::{cookie::Key, Expiry, MemoryStore, Session, SessionManagerLayer};
+
+const COUNTER_KEY: &str = "counter";
+
+#[derive(Default, Deserialize, Serialize)]
+struct Counter(usize);
+
+async fn handler(session: Session) -> impl IntoResponse {
+    let counter: Counter = session.get(COUNTER_KEY).await.unwrap().unwrap_or_default();
+    session.insert(COUNTER_KEY, counter.0 + 1).await.unwrap();
+    format!("Current count: {}", counter.0)
+}
+
+#[tokio::main]
+async fn main() {
+    let key = Key::generate(); // This is only used for demonstration purposes; provide a proper
+                               // cryptographic key in a real application.
+    let session_store = MemoryStore::default();
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::seconds(10)))
+        .with_signed(key);
+
+    let app = Router::new().route("/", get(handler)).layer(session_layer);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app.into_make_service())
+        .await
+        .unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,13 +341,22 @@
 //!
 //! ### Secure nature of cookies
 //!
-//! Session IDs are considered secure if sent over encrypted channels, and
-//! therefore are not signed or encrypted. Note that this assumption is
-//! predicated on the secure nature of the [`rand`](https://docs.rs/rand/latest/rand) crate
+//! Session IDs are considered secure if sent over encrypted channels. Note that
+//! this assumption is predicated on the secure nature of the [`rand`](https://docs.rs/rand/latest/rand) crate
 //! and its ability to generate securely-random values using the ChaCha block
 //! cipher with 12 rounds. It's also important to note that session cookies
 //! **must never** be sent over a public, insecure channel. Doing so is **not**
-//! secure.
+//! secure and will lead to compromised sessions!
+//!
+//! Additionally, sessions may be optionally signed or encrypted by enabling the
+//! `signed` and `private` feature flags, respectively. When enabled, the
+//! [`with_signed`](SessionManagerLayer::with_signed) and
+//! [`with_private`](SessionManagerLayer::with_private) methods become
+//! available. These methods take a cryptographic key which allows the session
+//! manager to leverage ciphertext as opposed to the default of plaintext. Note
+//! that no data is stored in the session ID beyond the session identifier
+//! itself and so this measure should be considered primarily effective as a
+//! defense in depth tactic.
 //!
 //! ## Key-value API
 //!

--- a/src/service.rs
+++ b/src/service.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 #[doc(hidden)]
-pub trait CookieController: Clone + Send + Sync + 'static {
+pub trait CookieController: Clone + Send + 'static {
     fn get(&self, cookies: &Cookies, name: &str) -> Option<Cookie<'static>>;
     fn add(&self, cookies: &Cookies, cookie: Cookie<'static>);
     fn remove(&self, cookies: &Cookies, cookie: Cookie<'static>);
@@ -415,7 +415,7 @@ impl<Store: SessionStore, C: CookieController> SessionManagerLayer<Store, C> {
     /// # */
     /// # let key: &Vec<u8> = &(0..64).collect();
     /// # let key: &[u8] = &key[..];
-    /// let key = Key::try_from(key).unwrap();
+    /// # let key = Key::try_from(key).unwrap();
     ///
     /// let session_store = MemoryStore::default();
     /// let session_service = SessionManagerLayer::new(session_store).with_signed(key);
@@ -441,7 +441,7 @@ impl<Store: SessionStore, C: CookieController> SessionManagerLayer<Store, C> {
     /// # */
     /// # let key: &Vec<u8> = &(0..64).collect();
     /// # let key: &[u8] = &key[..];
-    /// let key = Key::try_from(key).unwrap();
+    /// # let key = Key::try_from(key).unwrap();
     ///
     /// let session_store = MemoryStore::default();
     /// let session_service = SessionManagerLayer::new(session_store).with_private(key);


### PR DESCRIPTION
This provides session cookie signing and encryption via the feature flags, `signed` and `private` respectively.

Cryptographic treatment of the cookie value provides some additional properties that may be beneficial to an application's security posture. For example, while session keys are already composed of crytographically secure random values, and therefore exceedingly difficult for an attacker to guess, the addition of a cryptographic key presents another dimension an attacker must overcome in order to successfully guess a valid session.

Furthermore, while session stores may themselves be secured, e.g. via techniques like encryption at rest or session store implementors may provide measures to ensure plaintext values are not stored directly, signed or encrypted cookies again require knowing both the contents of a store and the cryptographic key (which is hopefully not colocated in the same store).

Altogether, signing and encryption are "defense in depth" techniques which can increase the security posture of an application.

Finally such cryptographic treatment is not necessary in all contexts and so is enabled here via an opt-in feature. When the flags are enabled, users must invoke the `with_signed` or `with_private` methods to ensure signing or encryption are leveraged.