### PR TITLE
Enable features that are needed to enable async unit tests.

### DIFF
--- a/tower-sessions-core/Cargo.toml
+++ b/tower-sessions-core/Cargo.toml
@@ -31,5 +31,6 @@ tokio = { workspace = true }
 tracing = { version = "0.1.40", features = ["log"] }
 
 [dev-dependencies]
-tower-sessions = { workspace = true }
+tower-sessions = { workspace = true, features = ["memory-store"] }
 tokio-test = "0.4.3"
+tokio = { workspace = true, features = ["rt", "macros"] }


### PR DESCRIPTION
Seems to me that the tokio test infra should be enabled by default when running `cargo test`.