### PR TITLE
ensure `session.set_expiry` updates record

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -351,7 +351,16 @@ macro_rules! route_tests {
             let res = app.clone().oneshot(req).await.unwrap();
             let session_cookie = get_session_cookie(res.headers()).unwrap();
 
-            assert_eq!(session_cookie.max_age(), Some(Duration::hours(1)));
+            let expected_duration = Duration::hours(1);
+            let actual_duration = session_cookie.max_age().unwrap();
+            let tolerance = Duration::seconds(1);
+
+            assert!(
+                actual_duration >= expected_duration - tolerance
+                    && actual_duration <= expected_duration + tolerance,
+                "Duration is not within the acceptable range: {:?}",
+                actual_duration
+            );
 
             let req = Request::builder()
                 .uri("/set_expiry")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@ use axum::{routing::get, Router};
 use axum_core::body::Body;
 use http::{header, HeaderMap};
 use http_body_util::BodyExt;
-use time::Duration;
+use time::{Duration, OffsetDateTime};
 use tower_cookies::{cookie, Cookie};
 use tower_sessions::{Expiry, Session, SessionManagerLayer, SessionStore};
 
@@ -49,6 +49,13 @@ fn routes() -> Router {
             "/flush",
             get(|session: Session| async move {
                 session.flush().await.unwrap();
+            }),
+        )
+        .route(
+            "/set_expiry",
+            get(|session: Session| async move {
+                let expiry = Expiry::AtDateTime(OffsetDateTime::now_utc() + Duration::days(1));
+                session.set_expiry(Some(expiry));
             }),
         )
 }
@@ -331,6 +338,40 @@ macro_rules! route_tests {
             assert_eq!(session_cookie.max_age(), Some(Duration::ZERO));
             assert_eq!(session_cookie.domain(), Some("localhost"));
             assert_eq!(session_cookie.path(), Some("/"));
+        }
+
+        #[tokio::test]
+        async fn set_expiry() {
+            let app = $create_app(Some(Duration::hours(1)), Some("localhost".to_string())).await;
+
+            let req = Request::builder()
+                .uri("/insert")
+                .body(Body::empty())
+                .unwrap();
+            let res = app.clone().oneshot(req).await.unwrap();
+            let session_cookie = get_session_cookie(res.headers()).unwrap();
+
+            assert_eq!(session_cookie.max_age(), Some(Duration::hours(1)));
+
+            let req = Request::builder()
+                .uri("/set_expiry")
+                .header(header::COOKIE, session_cookie.encoded().to_string())
+                .body(Body::empty())
+                .unwrap();
+            let res = app.oneshot(req).await.unwrap();
+
+            let session_cookie = get_session_cookie(res.headers()).unwrap();
+
+            let expected_duration = Duration::days(1);
+            let actual_duration = session_cookie.max_age().unwrap();
+            let tolerance = Duration::seconds(1);
+
+            assert!(
+                actual_duration >= expected_duration - tolerance
+                    && actual_duration <= expected_duration + tolerance,
+                "Duration is not within the acceptable range: {:?}",
+                actual_duration
+            );
         }
     };
 }

--- a/tower-sessions-core/src/session.rs
+++ b/tower-sessions-core/src/session.rs
@@ -507,7 +507,7 @@ impl Session {
         *self.expiry.lock()
     }
 
-    /// Set `expiry` give the given value.
+    /// Set `expiry` to the given value.
     ///
     /// This may be used within applications directly to alter the session's
     /// time to live.
@@ -521,7 +521,7 @@ impl Session {
     /// use tower_sessions::{session::Expiry, MemoryStore, Session};
     ///
     /// let store = Arc::new(MemoryStore::default());
-    /// let session = Session::new(None, store, None);
+    /// let session = Session::new(None, store.clone(), None);
     ///
     /// let expiry = Expiry::AtDateTime(OffsetDateTime::now_utc());
     /// session.set_expiry(Some(expiry));
@@ -529,8 +529,8 @@ impl Session {
     /// assert_eq!(session.expiry(), Some(expiry));
     /// ```
     pub fn set_expiry(&self, expiry: Option<Expiry>) {
-        let mut current_expiry = self.expiry.lock();
-        *current_expiry = expiry;
+        *self.expiry.lock() = expiry;
+        self.is_modified.store(true, atomic::Ordering::Release);
     }
 
     /// Get session expiry as `OffsetDateTime`.
@@ -651,6 +651,8 @@ impl Session {
     pub async fn save(&self) -> Result<()> {
         // N.B.: `get_record` will create a new record if one isn't found in the store.
         if let Some(record) = self.get_record().await?.as_mut() {
+            record.expiry_date = self.expiry_date();
+
             {
                 let mut session_id_guard = self.session_id.lock();
                 if session_id_guard.is_none() {

--- a/tower-sessions-core/src/session.rs
+++ b/tower-sessions-core/src/session.rs
@@ -521,7 +521,7 @@ impl Session {
     /// use tower_sessions::{session::Expiry, MemoryStore, Session};
     ///
     /// let store = Arc::new(MemoryStore::default());
-    /// let session = Session::new(None, store.clone(), None);
+    /// let session = Session::new(None, store, None);
     ///
     /// let expiry = Expiry::AtDateTime(OffsetDateTime::now_utc());
     /// session.set_expiry(Some(expiry));


### PR DESCRIPTION
This addresses a bug where using `set_expiry` after an expiry has been set would not update the underlying record and thus not update the actual cookie expiration.

Closes #174.