### PR TITLE
Add tests for the expiry date calculation.

### DIFF
--- a/tower-sessions-core/Cargo.toml
+++ b/tower-sessions-core/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true }
 tracing = { version = "0.1.40", features = ["log"] }
 
 [dev-dependencies]
+mockall = "0.12.1"
 tower-sessions = { workspace = true, features = ["memory-store"] }
 tokio-test = "0.4.3"
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/tower-sessions-core/src/session.rs
+++ b/tower-sessions-core/src/session.rs
@@ -37,6 +37,18 @@ pub enum Error {
     Store(#[from] session_store::Error),
 }
 
+/// Private function to defer to real time source
+#[cfg(not(test))]
+fn now_utc() -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+}
+
+/// Private function ot generate a fixed time for now during tests.
+#[cfg(test)]
+fn now_utc() -> OffsetDateTime {
+    time::macros::datetime!(1981-03-19 0:00 +0)
+}
+
 /// A session which allows HTTP applications to associate key-value pairs with
 /// visitors.
 #[derive(Debug, Clone)]
@@ -552,13 +564,13 @@ impl Session {
     /// ```
     pub fn expiry_date(&self) -> OffsetDateTime {
         let expiry = self.expiry.lock();
+        let now = now_utc();
+
         match *expiry {
-            Some(Expiry::OnInactivity(duration)) => {
-                OffsetDateTime::now_utc().saturating_add(duration)
-            }
+            Some(Expiry::OnInactivity(duration)) => now.saturating_add(duration),
             Some(Expiry::AtDateTime(datetime)) => datetime,
             Some(Expiry::OnSessionEnd) | None => {
-                OffsetDateTime::now_utc().saturating_add(DEFAULT_DURATION) // TODO: The default should probably be configurable.
+                now.saturating_add(DEFAULT_DURATION) // TODO: The default should probably be configurable.
             }
         }
     }
@@ -582,10 +594,7 @@ impl Session {
     /// assert!(session.expiry_age() < expected_duration.saturating_add(Duration::seconds(1)));
     /// ```
     pub fn expiry_age(&self) -> Duration {
-        std::cmp::max(
-            self.expiry_date() - OffsetDateTime::now_utc(),
-            Duration::ZERO,
-        )
+        std::cmp::max(self.expiry_date() - now_utc(), Duration::ZERO)
     }
 
     /// Returns `true` if the session has been modified during the request.
@@ -947,4 +956,58 @@ pub enum Expiry {
     /// This value may be extended manually with
     /// [`set_expiry`](Session::set_expiry).
     AtDateTime(OffsetDateTime),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod session {
+        use super::*;
+        use crate::session_store::MockSessionStore;
+
+        #[test]
+        fn test_get_expiry_date_no_expiry() {
+            let store = MockSessionStore::new();
+            let session = Session::new(None, Arc::new(store), None);
+            let fake_now = time::macros::datetime!(1981-03-19 0:00 +0);
+            let expected_offset = fake_now.saturating_add(DEFAULT_DURATION);
+            let expire_date = session.expiry_date();
+            assert_eq!(expected_offset, expire_date);
+        }
+
+        #[test]
+        fn test_get_expiry_date_expiry_onsessionend() {
+            let store = MockSessionStore::new();
+            let session = Session::new(None, Arc::new(store), Some(Expiry::OnSessionEnd));
+            let fake_now = time::macros::datetime!(1981-03-19 0:00 +0);
+            let expected_offset = fake_now.saturating_add(DEFAULT_DURATION);
+            let expire_date = session.expiry_date();
+            assert_eq!(expected_offset, expire_date);
+        }
+
+        #[test]
+        fn test_get_expiry_date_expiry_atdatetime() {
+            let store = MockSessionStore::new();
+            let at_time = time::macros::datetime!(1981-03-19 0:00 +0);
+            let session = Session::new(None, Arc::new(store), Some(Expiry::AtDateTime(at_time)));
+            let expire_date = session.expiry_date();
+            assert_eq!(at_time, expire_date);
+        }
+
+        #[test]
+        fn test_get_expiry_date_expiry_oninactivity() {
+            let store = MockSessionStore::new();
+            let fake_now = time::macros::datetime!(1981-03-19 0:00 +0);
+            let inacivity_duration = time::Duration::days(1);
+            let session = Session::new(
+                None,
+                Arc::new(store),
+                Some(Expiry::OnInactivity(inacivity_duration)),
+            );
+            let expected_offset = fake_now.saturating_add(inacivity_duration);
+            let expire_date = session.expiry_date();
+            assert_eq!(expected_offset, expire_date);
+        }
+    }
 }

--- a/tower-sessions-core/src/session_store.rs
+++ b/tower-sessions-core/src/session_store.rs
@@ -6,6 +6,9 @@ use async_trait::async_trait;
 
 use crate::session::{Id, Record};
 
+#[cfg(test)]
+use mockall::automock;
+
 /// Stores must map any errors that might occur during their use to this type.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -64,6 +67,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 ///     }
 /// }
 /// ```
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait SessionStore: Debug + Send + Sync + 'static {
     /// A method for saving a session in a store.


### PR DESCRIPTION
This is not pretty. I needed to make the test deterministic, so I just hacked in a fixed time for the current time when in test mode only. Hopefully, we can iterate and make this less ugly.