### PR TITLE
Id collision mitigation

### DIFF
--- a/memory-store/src/lib.rs
+++ b/memory-store/src/lib.rs
@@ -26,6 +26,7 @@ impl SessionStore for MemoryStore {
     async fn create(&self, record: &mut Record) -> session_store::Result<()> {
         let mut store_guard = self.0.lock().await;
         while store_guard.contains_key(&record.id) {
+            // Session ID collision mitigation.
             record.id = Id::default();
         }
         store_guard.insert(record.id, record.clone());

--- a/tower-sessions-core/Cargo.toml
+++ b/tower-sessions-core/Cargo.toml
@@ -34,3 +34,4 @@ tracing = { version = "0.1.40", features = ["log"] }
 tower-sessions = { workspace = true, features = ["memory-store"] }
 tokio-test = "0.4.3"
 tokio = { workspace = true, features = ["rt", "macros"] }
+mockall = "0.12.1"

--- a/tower-sessions-core/src/session_store.rs
+++ b/tower-sessions-core/src/session_store.rs
@@ -192,7 +192,7 @@ where
 {
     async fn create(&self, record: &mut Record) -> Result<()> {
         self.store.create(record).await?;
-        self.cache.save(record).await?;
+        self.cache.create(record).await?;
         Ok(())
     }
 

--- a/tower-sessions-core/src/session_store.rs
+++ b/tower-sessions-core/src/session_store.rs
@@ -66,7 +66,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// ```
 #[async_trait]
 pub trait SessionStore: Debug + Send + Sync + 'static {
-    /// Creates a new session in the store with the provided record.
+    /// Creates a new session in the store with the provided session record.
     ///
     /// Implementers must decide how to handle potential ID collisions. For
     /// example, they might generate a new unique ID or return `Error::Backend`.
@@ -82,14 +82,14 @@ pub trait SessionStore: Debug + Send + Sync + 'static {
     /// This method is intended for updating the state of an existing session.
     async fn save(&self, session_record: &Record) -> Result<()>;
 
-    /// Loads an existing session from the store using the provided ID.
+    /// Loads an existing session record from the store using the provided ID.
     ///
     /// If a session with the given ID exists, it is returned. If the session
     /// does not exist or has been invalidated (e.g., expired), `None` is
     /// returned.
     async fn load(&self, session_id: &Id) -> Result<Option<Record>>;
 
-    /// Deletes a session from the store using the provided ID.
+    /// Deletes a session record from the store using the provided ID.
     ///
     /// If the session exists, it is removed from the store.
     async fn delete(&self, session_id: &Id) -> Result<()>;

--- a/tower-sessions-core/src/session_store.rs
+++ b/tower-sessions-core/src/session_store.rs
@@ -31,6 +31,7 @@
 //!     async fn create(&self, record: &mut Record) -> session_store::Result<()> {
 //!         let mut store_guard = self.0.lock().await;
 //!         while store_guard.contains_key(&record.id) {
+//!             // Session ID collision mitigation.
 //!             record.id = Id::default();
 //!         }
 //!         store_guard.insert(record.id, record.clone());

--- a/tower-sessions-core/src/session_store.rs
+++ b/tower-sessions-core/src/session_store.rs
@@ -100,9 +100,9 @@ async fn default_create<S: SessionStore + ?Sized>(
     session_record: &mut Record,
 ) -> Result<()> {
     tracing::warn!(
-        "In order to mitigate potential ID collisions, stores must implement \
-         `SessionStore::create` directly. This warning indicates that `SessionStore::save` is \
-         being used instead."
+        "The default implementation of `SessionStore::create` is being used, which relies on \
+         `SessionStore::save`. To properly handle potential ID collisions, it is recommended that \
+         stores implement their own version of `SessionStore::create`."
     );
     store.save(session_record).await?;
     Ok(())


### PR DESCRIPTION
This patch introduces a new method, `create`, to the `SessionStore` trait to distinguish between creating a new session and updating an existing one. This distinction is crucial for mitigating the potential for session ID collisions.

Although the probability of session ID collisions is statistically low, given that IDs are composed of securely-random `i128` values, such collisions pose a significant security risk. A store that does not differentiate between session creation and updates could inadvertently allow an existing session to be accessed, leading to potential session takeovers.

To prevent this, stores must ensure the uniqueness of session IDs during creation. The new `create` method is designed to allow session store implementers to handle any conflicts and resolve them.

This change is a breaking interface update. As a transitional measure, we have provided a default implementation of create that wraps the existing save method. However, this default is not immune to the original issue. Therefore, it is imperative that stores override the create method with an implementation that adheres to the required uniqueness semantics, thereby effectively mitigating the risk of session ID collisions.

Closes #180.