### PR TITLE
Add option to always save session

### DIFF
--- a/tower-sessions-core/src/session.rs
+++ b/tower-sessions-core/src/session.rs
@@ -953,7 +953,7 @@ pub enum Expiry {
     /// Expire on [current session end][current-session-end], as defined by the
     /// browser.
     ///
-    /// [current-session-end]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie
+    /// [current-session-end]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#removal_defining_the_lifetime_of_a_cookie
     OnSessionEnd,
 
     /// Expire on inactivity.


### PR DESCRIPTION
This will allow to prolong session validity period with every valid request at the cost of higher session store write activity and adding set-cookie header to each response.