### PR TITLE
add tower-sessions-file-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ useful starting points.
 | Crate                                                                                                            | Persistent | Description                                                 |
 | ---------------------------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------- |
 | [`tower-sessions-dynamodb-store`](https://github.com/necrobious/tower-sessions-dynamodb-store)                   | Yes        | DynamoDB session store                                      |
+| [`tower-sessions-file-store`](https://github.com/mousetail/tower-sessions-file-store)                            | Yes        | Local filesystem store                     |
 | [`tower-sessions-firestore-store`](https://github.com/AtTheTavern/tower-sessions-firestore-store)                | Yes        | Firestore session store                                     |
 | [`tower-sessions-libsql-store`](https://github.com/daybowbow-dev/tower-sessions-libsql-store)                    | Yes        | libSQL session store                                        |
 | [`tower-sessions-mongodb-store`](https://github.com/maxcountryman/tower-sessions-stores/tree/main/mongodb-store) | Yes        | MongoDB session store                                       |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //! | Crate                                                                                                            | Persistent | Description                                |
 //! | ---------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------ |
 //! | [`tower-sessions-dynamodb-store`](https://github.com/necrobious/tower-sessions-dynamodb-store)                   | Yes        | DynamoDB session store                     |
+//! | [`tower-sessions-file-store`](https://github.com/mousetail/tower-sessions-file-store)                            | Yes        | Local filesystem store                     |
 //! | [`tower-sessions-firestore-store`](https://github.com/AtTheTavern/tower-sessions-firestore-store)                | Yes        | Firestore session store                    |
 //! | [`tower-sessions-libsql-store`](https://github.com/daybowbow-dev/tower-sessions-libsql-store)                    | Yes        | libSQL session store                       |
 //! | [`tower-sessions-mongodb-store`](https://github.com/maxcountryman/tower-sessions-stores/tree/main/mongodb-store) | Yes        | MongoDB session store                      |


### PR DESCRIPTION
I created a session store that stores sessions in local files, similar to the default behavior in frameworks like Django and PHP. This adds it to the list of session stores.