### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ tower-sessions-core = { version = "=0.14.0", path = "tower-sessions-core", defau
 tower-sessions-memory-store = { version = "=0.14.0", path = "memory-store" }
 
 async-trait = "0.1.74"
-parking_lot = { version = "0.12.1", features = ["serde"] }
-rmp-serde = { version = "1.1.2" }
-serde = "1.0.192"
 thiserror = "2.0.0"
 time = "0.3.30"
 tokio = { version = "1.32.0", default-features = false, features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ time = "0.3.30"
 tokio = { version = "1.32.0", default-features = false, features = ["sync"] }
 
 [dependencies]
-async-trait = "0.1.73"
 http = "1.0"
 tokio = { version = "1.32.0", features = ["sync"] }
 tower-layer = "0.3.2"


### PR DESCRIPTION
While going though the code to see how it worked I noticed there we're some unused dependencies. I think these were left over from when the session stores were still part of this repo. Since I already had the code checked out I figured I might as well make a PR to remove them.

It's not entirely clear to me why some dependencies are inherited from the workspace and some not. I could help clean this up if you want.